### PR TITLE
Fix run_track_2.py for DynamicWorkflow LLM execution

### DIFF
--- a/benchmark/cods_track2/run_track_2.py
+++ b/benchmark/cods_track2/run_track_2.py
@@ -81,7 +81,7 @@ def run_execution_workflow(
 
     wf = DynamicWorkflow(
         tasks=[task],
-        llm=llm_model,
+        
     )
 
     if generate_steps_only:


### PR DESCRIPTION
wf = DynamicWorkflow(
    tasks=[task],
    llm=llm_model,   # ❌ This argument is invalid
)

Fixes #43 