### PR TITLE
fix: lower minimum Python requirement to >=3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ name = "assetopsbench-mcp"
 version = "0.1.0"
 description = "Add your description here"
 readme = "INSTRUCTIONS.md"
-requires-python = ">=3.14"
+requires-python = ">=3.12"
 dependencies = [
     "couchdb3>=2.0.2",
     "fastmcp>=2.14.5",


### PR DESCRIPTION
## Summary

- Lowers `requires-python` from `>=3.14` to `>=3.12` in `pyproject.toml`
- Python 3.14 (alpha) has pydantic/pyo3 incompatibilities that cause a `PanicException` at MCP server startup; 3.12 is stable and LTS

Closes #180