### PR TITLE
Add validation for agent selection and dependency references in planner

### DIFF
--- a/src/workflow/planner.py
+++ b/src/workflow/planner.py
@@ -1,203 +1,148 @@
-from agent_hive.task import Task
-from pydantic import Field
-from typing import List
-from agent_hive.enum import ContextType
-import json
-from agent_hive.workflows.base_workflow import Workflow
-from reactxen.utils.model_inference import watsonx_llm
-import re
+"""LLM-based plan generation for the plan-execute orchestrator.
 
-from agent_hive.workflows.sequential import SequentialWorkflow
-from agent_hive.logger import get_custom_logger
-
-logger = get_custom_logger(__name__)
-
-
-class PlanningWorkflow(Workflow):
-    """
-    This class represents a planning workflow, where the (parent) task is decomposed into multiple subtasks by
-    LLM-based Rewoo planning and then executed sequentially.
-    """
-
-    llm: str = Field(description="LLM used by the task planning.")
-
-    def __init__(self, tasks: List[Task], llm: str):
-        self.tasks = tasks
-        self.memory = []
-        self.max_memory = 10
-        self.llm = llm
-        self._verify_tasks()
-
-    def _verify_tasks(self):
-        if not isinstance(self.tasks, list):
-            raise ValueError("tasks must be a list of Task objects")
-        if len(self.tasks) != 1:
-            raise ValueError("Planning only supports one task")
-        task = self.tasks[0]
-        if task.agents is None or len(task.agents) < 1:
-            raise ValueError("Task must have at least one agent")
-
-    def run(self, enable_summarization=False):
-        generated_steps = self.generate_steps()
-
-        if enable_summarization:
-            from agent_hive.agents.summarization_agent import SummarizationAgent
-
-            summarization_task = Task(
-                description=self.tasks[0].description,
-                expected_output=self.tasks[0].expected_output,
-                agents=[SummarizationAgent(llm=self.llm)],
-                context=generated_steps[:],
-            )
-            generated_steps.append(summarization_task)
-
-        sequential_workflow = SequentialWorkflow(
-            tasks=generated_steps, context_type=ContextType.SELECTED
-        )
-
-        return sequential_workflow.run()
-
-    def generate_steps(self, save_plan=False, saved_plan_filename=""):
-        task = self.tasks[0]
-        agent_descriptions = ""
-
-        for ii, aagent in enumerate(task.agents):
-            agent_descriptions += f"\n({ii + 1}) Agent name: {aagent.name}"
-            agent_descriptions += f"\nAgent description: {aagent.description}"
-            if "task_examples" in aagent.__dict__ and aagent.task_examples:
-                agent_descriptions += "\nTasks that agent can solve:"
-                for idx, task_example in enumerate(aagent.task_examples, start=1):
-                    agent_descriptions += f"\n{idx}. {task_example}"
-            agent_descriptions += "\n"
-
-        def get_prompt():
-            return f"""
-You are an AI assistant who makes step-by-step plan to solve a complicated problem under the help of external agents. 
-For each step, make one task followed by one agent-call.
-Each step denoted by #S1, #S2, #S3 ... can be referred to in later steps as a dependency.
-
-Each step must contain Task, Agent, Dependency and ExpectedOutput.
-
-## Output Format (Replace '<...>') ##
-
-## Step 1
-#Task1: <describe your task here>
-#Agent1: <agent_name>
-#Dependency1: None
-#ExpectedOutput1: <describe the expected output of the call>
-
-## Step 2
-#Task2: <describe next task>
-#Agent2: <agent_name>
-#Dependency2: [<you can use #S1 and more to represent previous outputs as a dependency>]
-#ExpectedOutput2: <describe the expected output of the call>
-
-And so on...
-
-Here are the available agents:
-{agent_descriptions}
- 
-You are going to solve the following complicated problem:
-{task.description}
-
-Guidelines:
-- Task should be something that can be solved by the agent.
-- A plan usually contains less than 5 steps.
-- Only output the generated plan.
-
-Output (your generated plan):
+Each plan step now includes the specific tool to call and its arguments,
+so the executor needs no additional LLM calls — it calls the tool directly.
 """
 
-        prompt = get_prompt()
+from __future__ import annotations
 
-        logger.info(f"Planning Prompt: \n{prompt}")
+import json
+import re
 
-        llm_response = watsonx_llm(prompt, model_id=self.llm)["generated_text"]
+from llm import LLMBackend
+from .models import Plan, PlanStep
 
-        logger.info(f"Plan: \n{llm_response}")
+_PLAN_PROMPT = """\
+You are a planning assistant for industrial asset operations and maintenance.
 
-        self.memory = []
+Decompose the question below into a sequence of subtasks. For each subtask,
+assign an agent and select the exact tool to call with its arguments.
 
-        task_pattern = r"#Task\d+: (.+)"
-        agent_pattern = r"#Agent\d+: (.+)"
-        dependency_pattern = r"#Dependency\d+: (.+)"
-        output_pattern = r"#ExpectedOutput\d+: (.+)"
+Available agents and tools:
+{agents}
 
-        tasks = re.findall(task_pattern, llm_response)
-        agents = re.findall(agent_pattern, llm_response)
-        dependencies = re.findall(dependency_pattern, llm_response)
-        outputs = re.findall(output_pattern, llm_response)
+For argument values that can only be known from a prior step's result,
+use the placeholder {{step_N}} (e.g., {{step_1}}) as the value.
 
-        if save_plan:
-            if not saved_plan_filename.endswith(".txt"):
-                saved_plan_filename += ".txt"
+Output format — one block per step, exactly:
 
-            saved_plan_text = f"Question: {task.description}\nPlan:\n{llm_response}"
-            with open(saved_plan_filename, "w") as f:
-                f.write(saved_plan_text)
+#Task1: <task description>
+#Agent1: <exact agent name>
+#Tool1: <exact tool name, or "none" if no tool call is needed>
+#Args1: <JSON object of tool arguments, e.g. {{"site_name": "MAIN"}}>
+#Dependency1: None
+#ExpectedOutput1: <what this step should produce>
 
-        planned_tasks = []
+#Task2: <task description>
+#Agent2: <exact agent name>
+#Tool2: <exact tool name>
+#Args2: {{"site_name": "MAIN", "asset_id": "{{step_1}}"}}
+#Dependency2: #S1
+#ExpectedOutput2: <what this step should produce>
 
-        for i in range(len(tasks)):
-            task_description = tasks[i]
+Rules:
+- Agent and tool names must exactly match those listed above.
+- #Args must be a valid JSON object on a single line.
+- Use {{step_N}} as a placeholder when an argument depends on step N's result.
+- Dependencies use #S<N> notation (e.g., #S1, #S2). Use "None" if none.
+- Keep tasks specific and actionable.
 
-            if i == len(agents):
-                break
+Question: {question}
 
-            agent_name = agents[i]
+Plan:
+"""
 
-            if i < len(dependencies):
-                dependency = dependencies[i]
-            else:
-                dependency = "None"
+_TASK_RE = re.compile(r"#Task(\d+):\s*(.+)")
+_AGENT_RE = re.compile(r"#Agent(\d+):\s*(.+)")
+_TOOL_RE = re.compile(r"#Tool(\d+):\s*(.+)")
+_ARGS_RE = re.compile(r"#Args(\d+):\s*(.+)")
+_DEP_RE = re.compile(r"#Dependency(\d+):\s*(.+)")
+_OUTPUT_RE = re.compile(r"#ExpectedOutput(\d+):\s*(.+)")
+_DEP_NUM_RE = re.compile(r"#S(\d+)")
 
-            if i < len(outputs):
-                expected_output = outputs[i]
-            else:
-                expected_output = ""
 
-            # Make sure the planner returned a valid agent name.
-            # Previously the code defaulted to the first agent, which could hide mistakes.
-            selected_agent = None
-            for agent in task.agents:
-                if agent.name == agent_name:
-                    selected_agent = agent
-                    break
+def parse_plan(raw: str) -> Plan:
+    """Parse an LLM-generated plan string into a Plan object."""
+    tasks = {int(m.group(1)): m.group(2).strip() for m in _TASK_RE.finditer(raw)}
+    agents = {int(m.group(1)): m.group(2).strip() for m in _AGENT_RE.finditer(raw)}
+    tools = {int(m.group(1)): m.group(2).strip() for m in _TOOL_RE.finditer(raw)}
+    deps_raw = {int(m.group(1)): m.group(2).strip() for m in _DEP_RE.finditer(raw)}
+    outputs = {int(m.group(1)): m.group(2).strip() for m in _OUTPUT_RE.finditer(raw)}
 
-            if selected_agent is None:
-                raise ValueError(
-                    f"Planner selected unknown agent '{agent_name}' at step {i + 1}"
-                )
+    args: dict[int, dict] = {}
+    for m in _ARGS_RE.finditer(raw):
+        n = int(m.group(1))
+        try:
+            args[n] = json.loads(m.group(2).strip())
+        except json.JSONDecodeError:
+            args[n] = {}
 
-            # Validate dependency references before building context.
-            # Ensures the planner only references valid previous steps.
-            if dependency != "None":
-                numbers = re.findall(r"#S(\d+)", dependency)
+    steps = []
+    for n in sorted(tasks):
+        raw_dep = deps_raw.get(n, "None").strip()
 
-                if not numbers:
+        if raw_dep.lower() == "none":
+            dependencies = []
+        else:
+            dependencies = [int(x) for x in _DEP_NUM_RE.findall(raw_dep)]
+
+            # Make sure dependency references only point to earlier valid steps.
+            if not dependencies:
+                raise ValueError(f"Invalid dependency format for step {n}: {raw_dep}")
+
+            for dep in dependencies:
+                if dep < 1 or dep >= n:
                     raise ValueError(
-                        f"Invalid dependency format at step {i + 1}: {dependency}"
+                        f"Invalid dependency reference for step {n}: #S{dep}"
                     )
 
-                step_numbers = [int(num) for num in numbers]
-
-                for step_num in step_numbers:
-                    if step_num < 1 or step_num > len(planned_tasks):
-                        raise ValueError(
-                            f"Invalid dependency reference at step {i + 1}: #S{step_num}"
-                        )
-
-                context = [planned_tasks[step_num - 1] for step_num in step_numbers]
-            else:
-                context = []
-
-            a_task = Task(
-                description=task_description,
-                expected_output=expected_output,
-                agents=[selected_agent],
-                context=context,
+        steps.append(
+            PlanStep(
+                step_number=n,
+                task=tasks[n],
+                agent=agents.get(n, ""),
+                tool=tools.get(n, ""),
+                tool_args=args.get(n, {}),
+                dependencies=dependencies,
+                expected_output=outputs.get(n, ""),
             )
+        )
 
-            planned_tasks.append(a_task)
+    return Plan(steps=steps, raw=raw)
 
-        return planned_tasks
+
+class Planner:
+    """Decomposes a question into a structured execution plan using an LLM."""
+
+    def __init__(self, llm: LLMBackend) -> None:
+        self._llm = llm
+
+    def generate_plan(
+        self,
+        question: str,
+        agent_descriptions: dict[str, str],
+    ) -> Plan:
+        """Generate a plan for a question given available agents and their tools.
+
+        Args:
+            question: The user question to answer.
+            agent_descriptions: Mapping of agent_name -> formatted tool signatures.
+
+        Returns:
+            A Plan where each PlanStep includes the tool to call and its arguments.
+        """
+        agents_text = "\n\n".join(
+            f"{name}:\n{desc}" for name, desc in agent_descriptions.items()
+        )
+        prompt = _PLAN_PROMPT.format(agents=agents_text, question=question)
+        raw = self._llm.generate(prompt)
+        plan = parse_plan(raw)
+
+        # Make sure the planner only uses agents that are actually available.
+        for step in plan.steps:
+            if step.agent not in agent_descriptions:
+                raise ValueError(
+                    f"Planner selected unknown agent '{step.agent}' at step {step.step_number}"
+                )
+
+        return plan


### PR DESCRIPTION
This change improves robustness in the planning workflow by adding validation in two areas:

1. Agent selection
After a plan is generated, each step is checked to ensure the referenced agent exists in the available agent list. If an unknown agent is returned by the planner, the system now raises a clear error instead of continuing with an invalid step.

2. Dependency validation
Step dependencies (#S1, #S2, etc.) are now validated during plan parsing to ensure they reference valid earlier steps. Invalid or forward references now raise an error before execution.

These checks help prevent malformed LLM-generated plans from progressing into the execution stage and make debugging planning issues easier as more agents and planning logic are added.