### PR TITLE
feat(agent): Add open-source BaseAgent utilizing MCP Executor composition

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -1,0 +1,27 @@
+# AssetOpsBench Standalone Agents
+
+This directory contains standalone, open-source agents that interface natively with the AssetOpsBench Model Context Protocol (MCP) environment.
+
+## The `BaseAgent` Architecture
+
+To avoid duplicating the complex `stdio` connection logic required by the MCP architecture, standalone agents in this directory inherit from the `BaseAgent` class. 
+
+### Composition over Inheritance
+The `BaseAgent` answers the architectural challenge of tool routing by using **composition**. Rather than inheriting from the `workflow.Executor` (which is tightly coupled to the DAG-based `PlanStep` generation), the `BaseAgent` instantiates an `Executor` under the hood. 
+
+This allows the agent to:
+1. Dynamically discover all tools using `get_available_tools()`.
+2. Seamlessly route tool executions to the correct MCP servers using `call_tool()`.
+3. Retain complete control over its own autonomous reasoning loop (e.g., ReAct, Tool-Calling, or custom heuristics).
+
+## How to Add a New Open-Source Agent
+
+To add a new agent (e.g., a Claude `claude_code.py` variant or a standard ReAct agent):
+
+1. **Create your file** in `src/agent/` (e.g., `my_custom_agent.py`).
+2. **Inherit** from `BaseAgent`.
+3. **Implement the `run(self, prompt: str)` method**:
+   - Call `await self.get_available_tools()` to inject the MCP tool schemas into your LLM's system prompt.
+   - Parse your LLM's output to detect required tool calls.
+   - Use `await self.call_tool(server_name, tool_name, args)` to execute the tools safely.
+   - Feed the `StepResult.response` back into your LLM until it reaches a final answer.

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -1,0 +1,5 @@
+"""Standalone open-source agents utilizing the MCP architecture."""
+
+from .base_agent import BaseAgent
+
+__all__ = ["BaseAgent"]

--- a/src/agent/base_agent.py
+++ b/src/agent/base_agent.py
@@ -1,0 +1,103 @@
+"""Base Agent implementation for open-source agents."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from llm import LLMBackend
+from workflow.executor import Executor
+from workflow.models import PlanStep, StepResult
+
+_log = logging.getLogger(__name__)
+
+
+class BaseAgent:
+    """A foundational class for standalone, open-source agents.
+
+    This class uses composition to leverage the existing `Executor` for MCP stdio
+    connections, tool discovery, and routing. Derived agents (e.g., ReAct, Claude)
+    should inherit from this class and implement their specific reasoning loops.
+    """
+
+    def __init__(
+        self,
+        llm: LLMBackend,
+        server_paths: dict[str, Path | str] | None = None,
+    ) -> None:
+        """Initialize the BaseAgent.
+
+        Args:
+            llm: The LLM backend to use for reasoning.
+            server_paths: Optional dictionary overriding default MCP server specs.
+        """
+        self._llm = llm
+        # Compose the Executor to handle complex MCP stdio connections cleanly
+        self._executor = Executor(llm, server_paths)
+        
+        # Maintain local state for step-by-step tool execution context
+        self._context: dict[int, StepResult] = {}
+        self._step_counter = 0
+
+    async def get_available_tools(self) -> dict[str, str]:
+        """Discover and format available tools from all registered MCP servers.
+
+        Returns:
+            A dictionary mapping server names to their formatted tool signatures.
+        """
+        _log.info("Discovering tools via MCP Executor...")
+        return await self._executor.get_agent_descriptions()
+
+    async def call_tool(
+        self,
+        server_name: str,
+        tool_name: str,
+        tool_args: dict[str, Any],
+        task_description: str = "Standalone tool execution",
+    ) -> StepResult:
+        """Execute a specific tool on a target MCP server.
+
+        Wraps the workflow Executor to safely route the tool call and manage state.
+
+        Args:
+            server_name: The name of the MCP server (e.g., 'IoTAgent').
+            tool_name: The exact name of the tool to execute.
+            tool_args: The arguments to pass to the tool.
+            task_description: An optional description of the task for logging.
+
+        Returns:
+            A StepResult containing the tool's response or error.
+        """
+        self._step_counter += 1
+        
+        # Package the tool call into a PlanStep so the Executor can process it natively
+        step = PlanStep(
+            step_number=self._step_counter,
+            task=task_description,
+            agent=server_name,
+            tool=tool_name,
+            tool_args=tool_args,
+            dependencies=[],
+            expected_output="",
+        )
+
+        _log.info("BaseAgent routing tool call: %s.%s", server_name, tool_name)
+        
+        # Execute the step using the underlying executor
+        result = await self._executor.execute_step(
+            step=step,
+            context=self._context,
+            question="Agent execution loop"
+        )
+        
+        # Store context for potential future reference in multi-step reasoning
+        self._context[self._step_counter] = result
+        return result
+
+    async def run(self, prompt: str) -> str:
+        """Core reasoning and execution loop.
+
+        Must be implemented by derived classes (e.g., ClaudeAgent, ReActAgent).
+        """
+        raise NotImplementedError("Derived agents must implement the run() method.")


### PR DESCRIPTION
Fixes #196

Adds the foundational architecture for standalone open-source agents.

Instead of directly inheriting from `workflow.Executor` (which is tightly coupled to `PlanStep` logic), this approach uses composition. The `BaseAgent` wraps the executor to handle the underlying MCP `stdio` connections and tool routing. This leaves the agent completely independent to implement its own autonomous reasoning loop (e.g., ReAct, Claude Code).

Changes:

Created `src/agent/base_agent.py` containing the `BaseAgent` class and a `call_tool()` wrapper.

Added `src/agent/README.md` to guide users on how to inherit from this base class and add their own components.

Testing:

Ran `uv run pytest src/ -v -k "not integration"`. All base tests pass. (Note: the 1 failure in `TestHistory` is just my local environment missing the CouchDB Docker fixture, entirely isolated from this module).