### PR TITLE
refactor: revert no-tool fix + update INSTRUCTIONS.md

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -146,7 +146,7 @@ uv run wo-mcp-server
 | `current_date_time`    | —           | Return the current UTC date and time as JSON           |
 | `current_time_english` | —           | Return the current UTC time as a human-readable string |
 
-### fmsr — Failure Mode and Sensor Reasoning
+### fmsr — Failure Mode and Sensor Relations
 
 **Path:** `src/servers/fmsr/main.py`
 **Requires:** `WATSONX_APIKEY`, `WATSONX_PROJECT_ID`, `WATSONX_URL` for unknown assets; curated lists for `chiller` and `ahu` work without credentials.

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -123,7 +123,7 @@ uv run wo-mcp-server
 
 ## MCP Servers
 
-### iot
+### iot — IoT Sensor Data
 
 **Path:** `src/servers/iot/main.py`
 **Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `IOT_DBNAME`)
@@ -135,7 +135,7 @@ uv run wo-mcp-server
 | `sensors` | `site_name`, `asset_id`                    | List sensor names for an asset                                          |
 | `history` | `site_name`, `asset_id`, `start`, `final?` | Fetch historical sensor readings for a time range (ISO 8601 timestamps) |
 
-### utilities
+### utilities — Utilities
 
 **Path:** `src/servers/utilities/main.py`
 **Requires:** nothing (no external services)
@@ -146,7 +146,7 @@ uv run wo-mcp-server
 | `current_date_time`    | —           | Return the current UTC date and time as JSON           |
 | `current_time_english` | —           | Return the current UTC time as a human-readable string |
 
-### fmsr
+### fmsr — Failure Mode and Sensor Reasoning
 
 **Path:** `src/servers/fmsr/main.py`
 **Requires:** `WATSONX_APIKEY`, `WATSONX_PROJECT_ID`, `WATSONX_URL` for unknown assets; curated lists for `chiller` and `ahu` work without credentials.
@@ -157,7 +157,7 @@ uv run wo-mcp-server
 | `get_failure_modes`               | `asset_name`                             | Return known failure modes for an asset. Uses a curated YAML list for chillers and AHUs; falls back to the LLM for other types.                         |
 | `get_failure_mode_sensor_mapping` | `asset_name`, `failure_modes`, `sensors` | For each (failure mode, sensor) pair, determine relevancy via LLM. Returns bidirectional `fm→sensors` and `sensor→fms` maps plus full per-pair details. |
 
-### wo
+### wo — Work Order
 
 **Path:** `src/servers/wo/main.py`
 **Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `WO_DBNAME`)
@@ -174,7 +174,7 @@ uv run wo-mcp-server
 | `predict_next_work_order`     | `equipment_id`, `start_date?`, `end_date?`            | Predict next work order type via Markov transition matrix built from historical sequence |
 | `analyze_alert_to_failure`    | `equipment_id`, `rule_id`, `start_date?`, `end_date?` | Probability that an alert rule leads to a work order; average hours to maintenance       |
 
-### tsfm
+### tsfm — Time Series Foundation Model
 
 **Path:** `src/servers/tsfm/main.py`
 **Requires:** `tsfm_public` (IBM Granite TSFM), `transformers`, `torch` for ML tools — imported lazily; static tools work without them.

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -96,29 +96,28 @@ uv run wo-mcp-server
 
 **CouchDB** — `iot` and `wo` servers
 
-| Variable | Default | Description |
-|---|---|---|
-| `COUCHDB_URL` | _(required)_ | CouchDB connection URL, e.g. `http://localhost:5984` |
-| `COUCHDB_USERNAME` | _(required)_ | CouchDB admin username |
-| `COUCHDB_PASSWORD` | _(required)_ | CouchDB admin password |
-| `IOT_DBNAME` | _(required)_ | IoT sensor database name (e.g. `chiller`) |
-| `WO_DBNAME` | `workorder` | Work order database name |
+| Variable           | Default                 | Description              |
+| ------------------ | ----------------------- | ------------------------ |
+| `COUCHDB_URL`      | `http://localhost:5984` | CouchDB connection URL   |
+| `COUCHDB_USERNAME` | `admin`                 | CouchDB admin username   |
+| `COUCHDB_PASSWORD` | `password`              | CouchDB admin password   |
+| `IOT_DBNAME`       | `chiller`               | IoT sensor database name |
+| `WO_DBNAME`        | `workorder`             | Work order database name |
 
-**WatsonX** — `fmsr` server (when `FMSR_MODEL_ID` starts with `watsonx/`) and `plan-execute` (when `--model-id` starts with `watsonx/`)
+**WatsonX** — plan-execute runner (when `--model-id` starts with `watsonx/`)
 
-| Variable | Default | Description |
-|---|---|---|
-| `WATSONX_APIKEY` | _(required)_ | IBM WatsonX API key |
-| `WATSONX_PROJECT_ID` | _(required)_ | IBM WatsonX project ID |
-| `WATSONX_URL` | `https://us-south.ml.cloud.ibm.com` | WatsonX endpoint (optional) |
+| Variable             | Default                             | Description                 |
+| -------------------- | ----------------------------------- | --------------------------- |
+| `WATSONX_APIKEY`     | _(required)_                        | IBM WatsonX API key         |
+| `WATSONX_PROJECT_ID` | _(required)_                        | IBM WatsonX project ID      |
+| `WATSONX_URL`        | `https://us-south.ml.cloud.ibm.com` | WatsonX endpoint (optional) |
 
-**LiteLLM** — `fmsr` server (when `FMSR_MODEL_ID` does not start with `watsonx/`) and `plan-execute` (when `--model-id` does not start with `watsonx/`, e.g. `litellm_proxy/…`)
+**LiteLLM** — plan-execute runner (when `--model-id` does not start with `watsonx/`, e.g. `litellm_proxy/…`)
 
-| Variable | Default | Description |
-|---|---|---|
-| `LITELLM_API_KEY` | _(required)_ | LiteLLM proxy API key |
+| Variable           | Default      | Description                                                          |
+| ------------------ | ------------ | -------------------------------------------------------------------- |
+| `LITELLM_API_KEY`  | _(required)_ | LiteLLM proxy API key                                                |
 | `LITELLM_BASE_URL` | _(required)_ | LiteLLM proxy base URL, e.g. `https://your-litellm-host.example.com` |
-
 
 ---
 
@@ -129,11 +128,11 @@ uv run wo-mcp-server
 **Path:** `src/servers/iot/main.py`
 **Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `IOT_DBNAME`)
 
-| Tool | Arguments | Description |
-|---|---|---|
-| `sites` | — | List all available sites |
-| `assets` | `site_name` | List all asset IDs for a site |
-| `sensors` | `site_name`, `asset_id` | List sensor names for an asset |
+| Tool      | Arguments                                  | Description                                                             |
+| --------- | ------------------------------------------ | ----------------------------------------------------------------------- |
+| `sites`   | —                                          | List all available sites                                                |
+| `assets`  | `site_name`                                | List all asset IDs for a site                                           |
+| `sensors` | `site_name`, `asset_id`                    | List sensor names for an asset                                          |
 | `history` | `site_name`, `asset_id`, `start`, `final?` | Fetch historical sensor readings for a time range (ISO 8601 timestamps) |
 
 ### utilities
@@ -141,11 +140,11 @@ uv run wo-mcp-server
 **Path:** `src/servers/utilities/main.py`
 **Requires:** nothing (no external services)
 
-| Tool | Arguments | Description |
-|---|---|---|
-| `json_reader` | `file_name` | Read and parse a JSON file from disk |
-| `current_date_time` | — | Return the current UTC date and time as JSON |
-| `current_time_english` | — | Return the current UTC time as a human-readable string |
+| Tool                   | Arguments   | Description                                            |
+| ---------------------- | ----------- | ------------------------------------------------------ |
+| `json_reader`          | `file_name` | Read and parse a JSON file from disk                   |
+| `current_date_time`    | —           | Return the current UTC date and time as JSON           |
+| `current_time_english` | —           | Return the current UTC time as a human-readable string |
 
 ### fmsr
 
@@ -153,9 +152,9 @@ uv run wo-mcp-server
 **Requires:** `WATSONX_APIKEY`, `WATSONX_PROJECT_ID`, `WATSONX_URL` for unknown assets; curated lists for `chiller` and `ahu` work without credentials.
 **Failure-mode data:** `src/servers/fmsr/failure_modes.yaml` (edit to add/change asset entries)
 
-| Tool | Arguments | Description |
-|---|---|---|
-| `get_failure_modes` | `asset_name` | Return known failure modes for an asset. Uses a curated YAML list for chillers and AHUs; falls back to the LLM for other types. |
+| Tool                              | Arguments                                | Description                                                                                                                                             |
+| --------------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `get_failure_modes`               | `asset_name`                             | Return known failure modes for an asset. Uses a curated YAML list for chillers and AHUs; falls back to the LLM for other types.                         |
 | `get_failure_mode_sensor_mapping` | `asset_name`, `failure_modes`, `sensors` | For each (failure mode, sensor) pair, determine relevancy via LLM. Returns bidirectional `fm→sensors` and `sensor→fms` maps plus full per-pair details. |
 
 ### wo
@@ -164,16 +163,16 @@ uv run wo-mcp-server
 **Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `WO_DBNAME`)
 **Data init:** Handled automatically by `docker compose -f src/couchdb/docker-compose.yaml up` (runs `src/couchdb/init_wo.py` inside the CouchDB container on first start)
 
-| Tool | Arguments | Description |
-|---|---|---|
-| `get_work_orders` | `equipment_id`, `start_date?`, `end_date?` | Retrieve all work orders for an equipment within an optional date range |
-| `get_preventive_work_orders` | `equipment_id`, `start_date?`, `end_date?` | Retrieve only preventive (PM) work orders |
-| `get_corrective_work_orders` | `equipment_id`, `start_date?`, `end_date?` | Retrieve only corrective (CM) work orders |
-| `get_events` | `equipment_id`, `start_date?`, `end_date?` | Retrieve all events (work orders, alerts, anomalies) |
-| `get_failure_codes` | — | List all failure codes with categories and descriptions |
-| `get_work_order_distribution` | `equipment_id`, `start_date?`, `end_date?` | Count work orders per (primary, secondary) failure code pair, sorted by frequency |
-| `predict_next_work_order` | `equipment_id`, `start_date?`, `end_date?` | Predict next work order type via Markov transition matrix built from historical sequence |
-| `analyze_alert_to_failure` | `equipment_id`, `rule_id`, `start_date?`, `end_date?` | Probability that an alert rule leads to a work order; average hours to maintenance |
+| Tool                          | Arguments                                             | Description                                                                              |
+| ----------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `get_work_orders`             | `equipment_id`, `start_date?`, `end_date?`            | Retrieve all work orders for an equipment within an optional date range                  |
+| `get_preventive_work_orders`  | `equipment_id`, `start_date?`, `end_date?`            | Retrieve only preventive (PM) work orders                                                |
+| `get_corrective_work_orders`  | `equipment_id`, `start_date?`, `end_date?`            | Retrieve only corrective (CM) work orders                                                |
+| `get_events`                  | `equipment_id`, `start_date?`, `end_date?`            | Retrieve all events (work orders, alerts, anomalies)                                     |
+| `get_failure_codes`           | —                                                     | List all failure codes with categories and descriptions                                  |
+| `get_work_order_distribution` | `equipment_id`, `start_date?`, `end_date?`            | Count work orders per (primary, secondary) failure code pair, sorted by frequency        |
+| `predict_next_work_order`     | `equipment_id`, `start_date?`, `end_date?`            | Predict next work order type via Markov transition matrix built from historical sequence |
+| `analyze_alert_to_failure`    | `equipment_id`, `rule_id`, `start_date?`, `end_date?` | Probability that an alert rule leads to a work order; average hours to maintenance       |
 
 ### tsfm
 
@@ -181,14 +180,14 @@ uv run wo-mcp-server
 **Requires:** `tsfm_public` (IBM Granite TSFM), `transformers`, `torch` for ML tools — imported lazily; static tools work without them.
 **Model checkpoints:** resolved relative to `PATH_TO_MODELS_DIR` (default: `src/servers/tsfm/artifacts/output/tuned_models`)
 
-| Tool | Arguments | Description |
-|---|---|---|
-| `get_ai_tasks` | — | List supported AI task types for time-series analysis |
-| `get_tsfm_models` | — | List available pre-trained TinyTimeMixer (TTM) model checkpoints |
-| `run_tsfm_forecasting` | `dataset_path`, `timestamp_column`, `target_columns`, `model_checkpoint?`, `forecast_horizon?`, `frequency_sampling?`, ... | Zero-shot TTM inference; returns path to a JSON predictions file |
-| `run_tsfm_finetuning` | `dataset_path`, `timestamp_column`, `target_columns`, `model_checkpoint?`, `save_model_dir?`, `n_finetune?`, `n_test?`, ... | Few-shot fine-tune a TTM model; returns saved checkpoint path and metrics file |
-| `run_tsad` | `dataset_path`, `tsfm_output_json`, `timestamp_column`, `target_columns`, `task?`, `false_alarm?`, `ad_model_type?`, ... | Conformal anomaly detection on top of a forecasting output JSON; returns CSV with anomaly labels |
-| `run_integrated_tsad` | `dataset_path`, `timestamp_column`, `target_columns`, `model_checkpoint?`, `false_alarm?`, `n_calibration?`, ... | End-to-end forecasting + anomaly detection in one call; returns combined CSV |
+| Tool                   | Arguments                                                                                                                   | Description                                                                                      |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `get_ai_tasks`         | —                                                                                                                           | List supported AI task types for time-series analysis                                            |
+| `get_tsfm_models`      | —                                                                                                                           | List available pre-trained TinyTimeMixer (TTM) model checkpoints                                 |
+| `run_tsfm_forecasting` | `dataset_path`, `timestamp_column`, `target_columns`, `model_checkpoint?`, `forecast_horizon?`, `frequency_sampling?`, ...  | Zero-shot TTM inference; returns path to a JSON predictions file                                 |
+| `run_tsfm_finetuning`  | `dataset_path`, `timestamp_column`, `target_columns`, `model_checkpoint?`, `save_model_dir?`, `n_finetune?`, `n_test?`, ... | Few-shot fine-tune a TTM model; returns saved checkpoint path and metrics file                   |
+| `run_tsad`             | `dataset_path`, `tsfm_output_json`, `timestamp_column`, `target_columns`, `task?`, `false_alarm?`, `ad_model_type?`, ...    | Conformal anomaly detection on top of a forecasting output JSON; returns CSV with anomaly labels |
+| `run_integrated_tsad`  | `dataset_path`, `timestamp_column`, `target_columns`, `model_checkpoint?`, `false_alarm?`, `n_calibration?`, ...            | End-to-end forecasting + anomaly detection in one call; returns combined CSV                     |
 
 ---
 
@@ -226,20 +225,20 @@ uv run plan-execute "What assets are available at site MAIN?"
 
 Flags:
 
-| Flag | Description |
-|---|---|
+| Flag                  | Description                                                                                                      |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `--model-id MODEL_ID` | litellm model string with provider prefix (default: `watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8`) |
-| `--server NAME=SPEC` | Override MCP servers with `NAME=SPEC` pairs (repeatable); SPEC is an entry-point name or path |
-| `--show-plan` | Print the generated plan before execution |
-| `--show-history` | Print each step result after execution |
-| `--json` | Output answer + plan + history as JSON |
+| `--server NAME=SPEC`  | Override MCP servers with `NAME=SPEC` pairs (repeatable); SPEC is an entry-point name or path                    |
+| `--show-plan`         | Print the generated plan before execution                                                                        |
+| `--show-history`      | Print each step result after execution                                                                           |
+| `--json`              | Output answer + plan + history as JSON                                                                           |
 
 The provider is encoded in the `--model-id` prefix:
 
-| Prefix | Provider | Required env vars |
-|---|---|---|
-| `watsonx/` | IBM WatsonX | `WATSONX_APIKEY`, `WATSONX_PROJECT_ID`, `WATSONX_URL` (optional) |
-| `litellm_proxy/` | LiteLLM proxy | `LITELLM_API_KEY`, `LITELLM_BASE_URL` |
+| Prefix           | Provider      | Required env vars                                                |
+| ---------------- | ------------- | ---------------------------------------------------------------- |
+| `watsonx/`       | IBM WatsonX   | `WATSONX_APIKEY`, `WATSONX_PROJECT_ID`, `WATSONX_URL` (optional) |
+| `litellm_proxy/` | LiteLLM proxy | `LITELLM_API_KEY`, `LITELLM_BASE_URL`                            |
 
 Examples:
 
@@ -326,11 +325,11 @@ print(result.answer)
 
 `OrchestratorResult` fields:
 
-| Field | Type | Description |
-|---|---|---|
-| `answer` | `str` | Final synthesised answer |
-| `plan` | `Plan` | The generated plan with its steps |
-| `history` | `list[StepResult]` | Per-step execution results |
+| Field     | Type               | Description                       |
+| --------- | ------------------ | --------------------------------- |
+| `answer`  | `str`              | Final synthesised answer          |
+| `plan`    | `Plan`             | The generated plan with its steps |
+| `history` | `list[StepResult]` | Per-step execution results        |
 
 ### Bring your own LLM
 
@@ -377,7 +376,12 @@ Add the following to your Claude Desktop `claude_desktop_config.json`:
   "mcpServers": {
     "utilities": {
       "command": "/path/to/uv",
-      "args": ["run", "--project", "/path/to/AssetOpsBench", "utilities-mcp-server"]
+      "args": [
+        "run",
+        "--project",
+        "/path/to/AssetOpsBench",
+        "utilities-mcp-server"
+      ]
     },
     "iot": {
       "command": "/path/to/uv",
@@ -410,6 +414,7 @@ uv run pytest src/ -v
 ```
 
 Integration tests are auto-skipped when the required service is not available:
+
 - IoT integration tests require `COUCHDB_URL` (set in `.env`)
 - Work order integration tests require `COUCHDB_URL` (set in `.env`)
 - FMSR integration tests require `WATSONX_APIKEY` (set in `.env`)

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -119,19 +119,6 @@ uv run wo-mcp-server
 | `LITELLM_API_KEY` | _(required)_ | LiteLLM proxy API key |
 | `LITELLM_BASE_URL` | _(required)_ | LiteLLM proxy base URL, e.g. `https://your-litellm-host.example.com` |
 
-**FMSR server**
-
-| Variable | Default | Description |
-|---|---|---|
-| `FMSR_MODEL_ID` | `watsonx/meta-llama/llama-3-3-70b-instruct` | LiteLLM model string used by the `fmsr` server for LLM-based failure mode queries |
-
-**TSFM server**
-
-| Variable | Default | Description |
-|---|---|---|
-| `PATH_TO_MODELS_DIR` | `src/servers/tsfm/artifacts/output/tuned_models` | Base directory for TTM model checkpoints |
-| `PATH_TO_DATASETS_DIR` | _(cwd)_ | Base directory for resolving relative dataset paths |
-| `PATH_TO_OUTPUTS_DIR` | _(cwd)_ | Base directory for resolving output/save paths |
 
 **General** — all servers
 

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -94,21 +94,50 @@ uv run wo-mcp-server
 
 ## Environment Variables
 
-| Variable | Required | Description |
+**CouchDB** — `iot` and `wo` servers
+
+| Variable | Default | Description |
 |---|---|---|
-| `COUCHDB_URL` | IoT + WO servers | CouchDB connection URL, e.g. `http://localhost:5984` |
-| `COUCHDB_USERNAME` | IoT + WO servers | CouchDB admin username |
-| `COUCHDB_PASSWORD` | IoT + WO servers | CouchDB admin password |
-| `IOT_DBNAME` | IoT server | IoT sensor database name (default: `chiller`) |
-| `WO_DBNAME` | WO server | Work order database name (default: `workorder`) |
-| `WATSONX_APIKEY` | `--platform watsonx` | IBM WatsonX API key |
-| `WATSONX_PROJECT_ID` | `--platform watsonx` | IBM WatsonX project ID |
-| `WATSONX_URL` | `--platform watsonx` | WatsonX endpoint (optional; defaults to `https://us-south.ml.cloud.ibm.com`) |
-| `LITELLM_API_KEY` | `--platform litellm` | LiteLLM API key |
-| `LITELLM_BASE_URL` | `--platform litellm` | LiteLLM base URL (e.g. `https://your-litellm-host.example.com`) |
-| `PATH_TO_MODELS_DIR` | TSFM server | Base directory for TTM model checkpoints (default: `src/servers/tsfm/artifacts/output/tuned_models`) |
-| `PATH_TO_DATASETS_DIR` | TSFM server | Base directory for resolving relative dataset paths |
-| `PATH_TO_OUTPUTS_DIR` | TSFM server | Base directory for resolving output/save paths |
+| `COUCHDB_URL` | _(required)_ | CouchDB connection URL, e.g. `http://localhost:5984` |
+| `COUCHDB_USERNAME` | _(required)_ | CouchDB admin username |
+| `COUCHDB_PASSWORD` | _(required)_ | CouchDB admin password |
+| `IOT_DBNAME` | _(required)_ | IoT sensor database name (e.g. `chiller`) |
+| `WO_DBNAME` | `workorder` | Work order database name |
+
+**WatsonX** — `fmsr` server (when `FMSR_MODEL_ID` starts with `watsonx/`) and `plan-execute` (when `--model-id` starts with `watsonx/`)
+
+| Variable | Default | Description |
+|---|---|---|
+| `WATSONX_APIKEY` | _(required)_ | IBM WatsonX API key |
+| `WATSONX_PROJECT_ID` | _(required)_ | IBM WatsonX project ID |
+| `WATSONX_URL` | `https://us-south.ml.cloud.ibm.com` | WatsonX endpoint (optional) |
+
+**LiteLLM** — `fmsr` server (when `FMSR_MODEL_ID` does not start with `watsonx/`) and `plan-execute` (when `--model-id` does not start with `watsonx/`, e.g. `litellm_proxy/…`)
+
+| Variable | Default | Description |
+|---|---|---|
+| `LITELLM_API_KEY` | _(required)_ | LiteLLM proxy API key |
+| `LITELLM_BASE_URL` | _(required)_ | LiteLLM proxy base URL, e.g. `https://your-litellm-host.example.com` |
+
+**FMSR server**
+
+| Variable | Default | Description |
+|---|---|---|
+| `FMSR_MODEL_ID` | `watsonx/meta-llama/llama-3-3-70b-instruct` | LiteLLM model string used by the `fmsr` server for LLM-based failure mode queries |
+
+**TSFM server**
+
+| Variable | Default | Description |
+|---|---|---|
+| `PATH_TO_MODELS_DIR` | `src/servers/tsfm/artifacts/output/tuned_models` | Base directory for TTM model checkpoints |
+| `PATH_TO_DATASETS_DIR` | _(cwd)_ | Base directory for resolving relative dataset paths |
+| `PATH_TO_OUTPUTS_DIR` | _(cwd)_ | Base directory for resolving output/save paths |
+
+**General** — all servers
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOG_LEVEL` | `WARNING` | Log level for MCP servers (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 
 ---
 

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -120,12 +120,6 @@ uv run wo-mcp-server
 | `LITELLM_BASE_URL` | _(required)_ | LiteLLM proxy base URL, e.g. `https://your-litellm-host.example.com` |
 
 
-**General** — all servers
-
-| Variable | Default | Description |
-|---|---|---|
-| `LOG_LEVEL` | `WARNING` | Log level for MCP servers (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-
 ---
 
 ## MCP Servers

--- a/src/workflow/executor.py
+++ b/src/workflow/executor.py
@@ -40,18 +40,6 @@ DEFAULT_SERVER_PATHS: dict[str, Path | str] = {
 
 _PLACEHOLDER_RE = re.compile(r"\{step_(\d+)\}")
 
-_DERIVE_VALUE_PROMPT = """\
-You are extracting a value from prior step results for a plan step.
-
-Task: {task}
-Expected output: {expected_output}
-
-Results from prior steps:
-{context}
-
-Provide exactly the value requested — no explanation, just the value itself.
-"""
-
 _ARG_RESOLUTION_PROMPT = """\
 You are resolving tool argument values for one step in a multi-step plan.
 
@@ -128,9 +116,7 @@ class Executor:
         """Execute a single plan step.
 
         1. Resolve the MCP server assigned to this step.
-        2. If no tool is specified and the step has dependencies, call the LLM to
-           derive the value from prior step results.  If no dependencies, return
-           expected_output directly.
+        2. If no tool is specified, return expected_output directly.
         3. If tool_args contain {{step_N}} placeholders, call the LLM to resolve
            them from prior step results.
         4. Call the tool and return its result.
@@ -149,25 +135,11 @@ class Executor:
             )
 
         if not step.tool or step.tool.lower() in ("none", "null"):
-            if step.dependencies and any(d in context for d in step.dependencies):
-                context_text = "\n".join(
-                    f"Step {n}: {context[n].response}"
-                    for n in sorted(step.dependencies)
-                    if n in context
-                )
-                prompt = _DERIVE_VALUE_PROMPT.format(
-                    task=step.task,
-                    expected_output=step.expected_output,
-                    context=context_text,
-                )
-                response = self._llm.generate(prompt).strip()
-            else:
-                response = step.expected_output
             return StepResult(
                 step_number=step.step_number,
                 task=step.task,
                 server=step.server,
-                response=response,
+                response=step.expected_output,
                 tool=step.tool,
                 tool_args=step.tool_args,
             )

--- a/src/workflow/tests/test_runner.py
+++ b/src/workflow/tests/test_runner.py
@@ -122,7 +122,7 @@ async def test_orchestrator_unknown_server_recorded_as_error(sequential_llm):
 
 @pytest.mark.anyio
 async def test_orchestrator_no_tool_returns_expected_output(sequential_llm):
-    """A step with tool=none and no dependencies returns expected_output directly."""
+    """A step with tool=none returns expected_output directly (no MCP call)."""
     plan_with_no_tool = (
         "#Task1: Answer from context\n"
         "#Server1: iot\n"
@@ -137,34 +137,6 @@ async def test_orchestrator_no_tool_returns_expected_output(sequential_llm):
 
     assert result.history[0].response == "42"
     assert result.history[0].success is True
-
-
-@pytest.mark.anyio
-async def test_executor_no_tool_with_dependency_derives_value(mock_llm):
-    """A no-tool step with a dependency calls the LLM to derive its response."""
-    from pathlib import Path
-
-    derived = "Chiller 6"
-    llm = mock_llm(derived)
-    executor = Executor(llm, server_paths={"iot": Path("/fake/server.py")})
-
-    plan = Plan(
-        steps=[
-            _make_step(1, tool="assets", tool_args={"site_name": "MAIN"}),
-            _make_step(2, tool="none", tool_args={}, deps=[1]),
-        ],
-        raw="",
-    )
-    assets_resp = '{"assets": ["Chiller 6"]}'
-    call_mock = AsyncMock(return_value=assets_resp)
-    with (
-        patch("workflow.executor._list_tools", new=AsyncMock(return_value=_MOCK_TOOLS)),
-        patch("workflow.executor._call_tool", new=call_mock),
-    ):
-        results = await executor.execute_plan(plan, "Q")
-
-    assert results[1].response == derived
-    assert results[1].success is True
 
 
 # ── executor unit tests ───────────────────────────────────────────────────────


### PR DESCRIPTION
Continuation of #218 (merged early). Contains 7 pending commits:

- Revert "fix: no-tool steps with dependencies now derive value via LLM"
- docs: rewrite Environment Variables section in INSTRUCTIONS.md
- docs: remove FMSR server and TSFM server env var sections
- docs: remove General env var section
- docs: update env var defaults from .env.public
- docs: append full names to MCP server subsection headings
- docs: rename FMSR full name to Failure Mode and Sensor Relations