### PR TITLE
fix: strip tool signature suffix copied by LLM from server descriptions

### DIFF
--- a/src/workflow/planner.py
+++ b/src/workflow/planner.py
@@ -60,7 +60,12 @@ def parse_plan(raw: str) -> Plan:
     """Parse an LLM-generated plan string into a Plan object."""
     tasks = {int(m.group(1)): m.group(2).strip() for m in _TASK_RE.finditer(raw)}
     servers = {int(m.group(1)): m.group(2).strip() for m in _SERVER_RE.finditer(raw)}
-    tools = {int(m.group(1)): m.group(2).strip() for m in _TOOL_RE.finditer(raw)}
+    # Strip any trailing signature the LLM may copy from the server description
+    # format "tool_name(param: type)" — only the bare name is needed.
+    tools = {
+        int(m.group(1)): m.group(2).strip().split("(")[0].strip()
+        for m in _TOOL_RE.finditer(raw)
+    }
     deps_raw = {int(m.group(1)): m.group(2).strip() for m in _DEP_RE.finditer(raw)}
     outputs = {int(m.group(1)): m.group(2).strip() for m in _OUTPUT_RE.finditer(raw)}
 

--- a/src/workflow/tests/test_planner.py
+++ b/src/workflow/tests/test_planner.py
@@ -62,6 +62,27 @@ class TestParsePlan:
         assert plan.steps[0].tool == "sites"
         assert plan.steps[1].tool == "assets"
 
+    def test_tool_name_signature_stripped(self):
+        """LLM sometimes copies the 'tool(params)' format from server descriptions.
+
+        parse_plan must strip the signature so the bare name reaches _call_tool.
+        """
+        raw = (
+            "#Task1: Get sites\n"
+            "#Server1: iot\n"
+            "#Tool1: sites()\n"
+            "#Dependency1: None\n"
+            "#ExpectedOutput1: Sites\n\n"
+            "#Task2: Get assets\n"
+            "#Server2: iot\n"
+            "#Tool2: assets(site_name: string)\n"
+            "#Dependency2: #S1\n"
+            "#ExpectedOutput2: Assets"
+        )
+        plan = parse_plan(raw)
+        assert plan.steps[0].tool == "sites"
+        assert plan.steps[1].tool == "assets"
+
     def test_tool_args_always_empty(self):
         """Planner no longer generates args — tool_args is always {}."""
         plan = parse_plan(_TWO_STEP)


### PR DESCRIPTION
## Summary

- The planner's server description format is `tool(param: type): desc`, which the LLM sometimes echoes verbatim in `#Tool` lines (e.g. `#Tool2: assets(site_name: string)`)
- This caused MCP to log `Tool 'assets(site_name: string)' not listed, no validation will be performed` and the tool call to fail
- `parse_plan` now splits on `(` and keeps only the bare tool name

## Test plan

- [ ] `test_tool_name_signature_stripped` — new regression test covering `sites()` and `assets(site_name: string)` input
- [ ] All 66 workflow tests pass