### PR TITLE
chore: add stale bot to auto-close inactive issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been inactive for 30 days. It will be closed in 7 days
+            unless there is further activity.
+          close-issue-message: >
+            Closed due to 30 days of inactivity. Please reopen if this is still relevant.
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
+          stale-issue-label: stale
+          exempt-issue-labels: pinned,security,in-progress
+          days-before-pr-stale: -1
+          days-before-pr-close: -1


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/stale.yml` using `actions/stale@v9`
- Labels issues as `stale` after 30 days of inactivity
- Closes them 7 days later if still no activity
- PRs are exempt (disabled via `-1`)
- Exempt labels: `pinned`, `security`, `in-progress`

## Test plan

- [ ] Merge and verify the workflow appears in the Actions tab
- [ ] Optionally trigger manually via `workflow_dispatch` to confirm it runs without errors