### PR TITLE
feat: add OpenAI Agents SDK agent runner

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -326,7 +326,7 @@ Flags:
 
 | Flag                  | Description                                                                  |
 | --------------------- | ---------------------------------------------------------------------------- |
-| `--model-id MODEL_ID` | Claude model ID (default: `claude-opus-4-6`)                                 |
+| `--model-id MODEL_ID` | Claude model ID (default: `litellm_proxy/aws/claude-opus-4-6`)               |
 | `--max-turns N`       | Maximum agentic loop turns (default: 30)                                     |
 | `--show-trajectory`      | Print each turn's text, tool calls, and token usage                          |
 | `--json`              | Output full trajectory (turns, tool calls, token counts) as JSON             |
@@ -342,11 +342,11 @@ The `--model-id` prefix determines the backend:
 Examples:
 
 ```bash
-# Direct Anthropic API
+# LiteLLM proxy (default)
 uv run claude-agent "$query"
 
-# LiteLLM proxy
-uv run claude-agent --model-id litellm_proxy/aws/claude-opus-4-6 "$query"
+# Direct Anthropic API
+uv run claude-agent --model-id claude-opus-4-6 "$query"
 
 # Show full trajectory (turns, tool calls, token usage)
 uv run claude-agent --show-trajectory "$query"

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -25,6 +25,10 @@ This directory contains the MCP servers and infrastructure for the AssetOpsBench
   - [How it works](#how-it-works-1)
   - [CLI](#cli-1)
   - [Python API](#python-api-1)
+- [OpenAI Agent](#openai-agent)
+  - [How it works](#how-it-works-2)
+  - [CLI](#cli-2)
+  - [Python API](#python-api-2)
 - [Connect to Claude Desktop](#connect-to-claude-desktop)
 - [Running Tests](#running-tests)
 - [Architecture](#architecture)
@@ -125,6 +129,14 @@ uv run vibration-mcp-server
 | ------------------ | ------------ | -------------------------------------------------------------------- |
 | `LITELLM_API_KEY`  | _(required)_ | LiteLLM proxy API key                                                |
 | `LITELLM_BASE_URL` | _(required)_ | LiteLLM proxy base URL, e.g. `https://your-litellm-host.example.com` |
+
+**OpenAI** — openai-agent runner
+
+| Variable         | Default      | Description    |
+| ---------------- | ------------ | -------------- |
+| `OPENAI_API_KEY` | _(required)_ | OpenAI API key |
+
+> **Note:** The `openai-agent` runner also supports LiteLLM proxy via the `litellm_proxy/` model-id prefix — in that case set `LITELLM_API_KEY` and `LITELLM_BASE_URL` instead.
 
 ---
 
@@ -491,6 +503,112 @@ for tc in traj.all_tool_calls:
 
 ---
 
+## OpenAI Agent
+
+`src/agent/openai_agent/` uses the **[OpenAI Agents SDK](https://github.com/openai/openai-agents-python)** (`openai-agents`) to drive the same MCP servers. Like `ClaudeAgentRunner`, there is no explicit plan — the SDK's built-in agentic loop handles tool discovery, invocation, and multi-turn reasoning autonomously.
+
+### How it works
+
+```
+OpenAIAgentRunner.run(question)
+  │
+  └─ OpenAI Agents SDK Runner.run loop
+       • connects to each MCP server over stdio (MCPServerStdio)
+       • GPT decides which tools to call and in what order
+       • tool calls and results are handled internally by the SDK
+       • final answer is returned via result.final_output
+```
+
+### CLI
+
+After `uv sync`, the `openai-agent` command is available:
+
+```bash
+uv run openai-agent "What sensors are on Chiller 6?"
+```
+
+Flags:
+
+| Flag                  | Description                                                              |
+| --------------------- | ------------------------------------------------------------------------ |
+| `--model-id MODEL_ID` | Model ID, optionally prefixed with `litellm_proxy/` (default: `gpt-4o`) |
+| `--max-turns N`       | Maximum agentic loop turns (default: 30)                                 |
+| `--show-trajectory`   | Print each turn's text, tool calls, and token usage                      |
+| `--json`              | Output full trajectory (turns, tool calls, token counts) as JSON         |
+| `--verbose`           | Show INFO-level logs on stderr                                           |
+
+The `--model-id` prefix determines the backend:
+
+| Prefix           | Backend       | Required env vars                     |
+| ---------------- | ------------- | ------------------------------------- |
+| _(none)_         | OpenAI API    | `OPENAI_API_KEY`                      |
+| `litellm_proxy/` | LiteLLM proxy | `LITELLM_API_KEY`, `LITELLM_BASE_URL` |
+
+Examples:
+
+```bash
+# Direct OpenAI API
+uv run openai-agent "What assets are at site MAIN?"
+
+# Different model
+uv run openai-agent --model-id gpt-4.1-mini "What sensors are on Chiller 6?"
+
+# LiteLLM proxy
+uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 "What sensors are on Chiller 6?"
+
+# Show full trajectory (turns, tool calls, token usage)
+uv run openai-agent --show-trajectory "What are the failure modes for a chiller?"
+
+# Machine-readable trajectory
+uv run openai-agent --json "What is the current time?" | jq .turns
+```
+
+### Python API
+
+```python
+import asyncio
+from agent.openai_agent import OpenAIAgentRunner
+
+# Direct OpenAI API
+runner = OpenAIAgentRunner(model="gpt-4o")
+result = asyncio.run(runner.run("What sensors are on Chiller 6?"))
+print(result.answer)
+
+# Via LiteLLM proxy
+runner = OpenAIAgentRunner(model="litellm_proxy/azure/gpt-5.4")
+result = asyncio.run(runner.run("What sensors are on Chiller 6?"))
+```
+
+`AgentResult` fields:
+
+| Field        | Type         | Description                                      |
+| ------------ | ------------ | ------------------------------------------------ |
+| `answer`     | `str`        | Final answer from the agent                      |
+| `trajectory` | `Trajectory` | Full execution trace (turns, tool calls, tokens)  |
+
+`Trajectory` fields:
+
+| Field                 | Type              | Description                          |
+| --------------------- | ----------------- | ------------------------------------ |
+| `turns`               | `list[TurnRecord]`| One record per assistant turn        |
+| `total_input_tokens`  | `int`             | Sum of input tokens across all turns |
+| `total_output_tokens` | `int`             | Sum of output tokens across all turns|
+| `all_tool_calls`      | `list[ToolCall]`  | Flat list of every tool call made    |
+
+Each `TurnRecord` has `index`, `text`, `tool_calls`, `input_tokens`, `output_tokens`.
+Each `ToolCall` has `name`, `input`, `id`, `output`.
+
+```python
+traj = result.trajectory
+print(f"{traj.total_input_tokens} input / {traj.total_output_tokens} output tokens")
+for tc in traj.all_tool_calls:
+    print(f"  {tc.name}: {tc.input}")
+    if tc.output is not None:
+        print(f"    -> {tc.output}")
+```
+
+---
+
 ## Connect to Claude Desktop
 
 Add the following to your Claude Desktop `claude_desktop_config.json`:
@@ -599,6 +717,13 @@ uv run pytest src/ -v
 │  ┌─────────────────────────────────────────┐                 │
 │  │  claude-agent-sdk agentic loop          │                 │
 │  │  Claude decides tools + order autonomously               │
+│  │  Trajectory (turns, tool calls, tokens) collected        │
+│  └─────────────────────────────────────────┘                 │
+│                                                              │
+│  OpenAIAgentRunner.run(question)                             │
+│  ┌─────────────────────────────────────────┐                 │
+│  │  openai-agents SDK Runner.run loop      │                 │
+│  │  GPT decides tools + order autonomously                  │
 │  │  Trajectory (turns, tool calls, tokens) collected        │
 │  └─────────────────────────────────────────┘                 │
 └──────────────────────────┬───────────────────────────────────┘

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -223,14 +223,12 @@ The CLI examples below use a `$query` shell variable so you can swap in any ques
 
 ```bash
 # Simple single-server queries
-query="What assets are at site MAIN?"
 query="What sensors are on Chiller 6?"
-query="What is the current time?"
+query="Is LSTM model supported in TSFM?"
+query="Get the work order of equipment CWC04013 for year 2017."
 
 # Multi-step / multi-server queries
-query="What are the failure modes for a chiller?"
-query="How many work orders does equipment CWC04014 have, and what is the most common failure code?"
-query="For equipment CWC04013, how many preventive vs corrective work orders were completed?"
+query="What is the current date and time? Also list assets at site MAIN. Also get sensor list and failure mode list for any of the chiller at site MAIN."
 ```
 
 ## Plan-Execute Agent

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -25,6 +25,10 @@ This directory contains the MCP servers and infrastructure for the AssetOpsBench
   - [How it works](#how-it-works-1)
   - [CLI](#cli-1)
   - [Python API](#python-api-1)
+- [OpenAI Agent](#openai-agent)
+  - [How it works](#how-it-works-2)
+  - [CLI](#cli-2)
+  - [Python API](#python-api-2)
 - [Connect to Claude Desktop](#connect-to-claude-desktop)
 - [Running Tests](#running-tests)
 - [Architecture](#architecture)
@@ -125,6 +129,12 @@ uv run vibration-mcp-server
 | ------------------ | ------------ | -------------------------------------------------------------------- |
 | `LITELLM_API_KEY`  | _(required)_ | LiteLLM proxy API key                                                |
 | `LITELLM_BASE_URL` | _(required)_ | LiteLLM proxy base URL, e.g. `https://your-litellm-host.example.com` |
+
+**OpenAI** — openai-agent runner
+
+| Variable         | Default      | Description      |
+| ---------------- | ------------ | ---------------- |
+| `OPENAI_API_KEY` | _(required)_ | OpenAI API key   |
 
 ---
 
@@ -491,6 +501,99 @@ for tc in traj.all_tool_calls:
 
 ---
 
+## OpenAI Agent
+
+`src/agent/openai_agent/` uses the **[OpenAI Agents SDK](https://github.com/openai/openai-agents-python)** (`openai-agents`) to drive the same MCP servers. Like `ClaudeAgentRunner`, there is no explicit plan — the SDK's built-in agentic loop handles tool discovery, invocation, and multi-turn reasoning autonomously.
+
+### How it works
+
+```
+OpenAIAgentRunner.run(question)
+  │
+  └─ OpenAI Agents SDK Runner.run loop
+       • connects to each MCP server over stdio (MCPServerStdio)
+       • GPT decides which tools to call and in what order
+       • tool calls and results are handled internally by the SDK
+       • final answer is returned via result.final_output
+```
+
+### CLI
+
+After `uv sync`, the `openai-agent` command is available:
+
+```bash
+uv run openai-agent "What sensors are on Chiller 6?"
+```
+
+Flags:
+
+| Flag                  | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `--model-id MODEL_ID` | OpenAI model ID (default: `gpt-4o`)                         |
+| `--max-turns N`       | Maximum agentic loop turns (default: 30)                     |
+| `--show-trajectory`   | Print each turn's text, tool calls, and token usage          |
+| `--json`              | Output full trajectory (turns, tool calls, token counts) as JSON |
+| `--verbose`           | Show INFO-level logs on stderr                               |
+
+Required env var: `OPENAI_API_KEY`
+
+Examples:
+
+```bash
+# Default model (gpt-4o)
+uv run openai-agent "What assets are at site MAIN?"
+
+# Different model
+uv run openai-agent --model-id gpt-4.1-mini "What sensors are on Chiller 6?"
+
+# Show full trajectory (turns, tool calls, token usage)
+uv run openai-agent --show-trajectory "What are the failure modes for a chiller?"
+
+# Machine-readable trajectory
+uv run openai-agent --json "What is the current time?" | jq .turns
+```
+
+### Python API
+
+```python
+import asyncio
+from agent.openai_agent import OpenAIAgentRunner
+
+runner = OpenAIAgentRunner(model="gpt-4o")
+result = asyncio.run(runner.run("What sensors are on Chiller 6?"))
+print(result.answer)
+```
+
+`AgentResult` fields:
+
+| Field        | Type         | Description                                      |
+| ------------ | ------------ | ------------------------------------------------ |
+| `answer`     | `str`        | Final answer from the agent                      |
+| `trajectory` | `Trajectory` | Full execution trace (turns, tool calls, tokens)  |
+
+`Trajectory` fields:
+
+| Field                 | Type              | Description                          |
+| --------------------- | ----------------- | ------------------------------------ |
+| `turns`               | `list[TurnRecord]`| One record per assistant turn        |
+| `total_input_tokens`  | `int`             | Sum of input tokens across all turns |
+| `total_output_tokens` | `int`             | Sum of output tokens across all turns|
+| `all_tool_calls`      | `list[ToolCall]`  | Flat list of every tool call made    |
+
+Each `TurnRecord` has `index`, `text`, `tool_calls`, `input_tokens`, `output_tokens`.
+Each `ToolCall` has `name`, `input`, `id`, `output`.
+
+```python
+traj = result.trajectory
+print(f"{traj.total_input_tokens} input / {traj.total_output_tokens} output tokens")
+for tc in traj.all_tool_calls:
+    print(f"  {tc.name}: {tc.input}")
+    if tc.output is not None:
+        print(f"    -> {tc.output}")
+```
+
+---
+
 ## Connect to Claude Desktop
 
 Add the following to your Claude Desktop `claude_desktop_config.json`:
@@ -599,6 +702,13 @@ uv run pytest src/ -v
 │  ┌─────────────────────────────────────────┐                 │
 │  │  claude-agent-sdk agentic loop          │                 │
 │  │  Claude decides tools + order autonomously               │
+│  │  Trajectory (turns, tool calls, tokens) collected        │
+│  └─────────────────────────────────────────┘                 │
+│                                                              │
+│  OpenAIAgentRunner.run(question)                             │
+│  ┌─────────────────────────────────────────┐                 │
+│  │  openai-agents SDK Runner.run loop      │                 │
+│  │  GPT decides tools + order autonomously                  │
 │  │  Trajectory (turns, tool calls, tokens) collected        │
 │  └─────────────────────────────────────────┘                 │
 └──────────────────────────┬───────────────────────────────────┘

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -25,10 +25,6 @@ This directory contains the MCP servers and infrastructure for the AssetOpsBench
   - [How it works](#how-it-works-1)
   - [CLI](#cli-1)
   - [Python API](#python-api-1)
-- [OpenAI Agent](#openai-agent)
-  - [How it works](#how-it-works-2)
-  - [CLI](#cli-2)
-  - [Python API](#python-api-2)
 - [Connect to Claude Desktop](#connect-to-claude-desktop)
 - [Running Tests](#running-tests)
 - [Architecture](#architecture)
@@ -129,12 +125,6 @@ uv run vibration-mcp-server
 | ------------------ | ------------ | -------------------------------------------------------------------- |
 | `LITELLM_API_KEY`  | _(required)_ | LiteLLM proxy API key                                                |
 | `LITELLM_BASE_URL` | _(required)_ | LiteLLM proxy base URL, e.g. `https://your-litellm-host.example.com` |
-
-**OpenAI** — openai-agent runner
-
-| Variable         | Default      | Description      |
-| ---------------- | ------------ | ---------------- |
-| `OPENAI_API_KEY` | _(required)_ | OpenAI API key   |
 
 ---
 
@@ -501,99 +491,6 @@ for tc in traj.all_tool_calls:
 
 ---
 
-## OpenAI Agent
-
-`src/agent/openai_agent/` uses the **[OpenAI Agents SDK](https://github.com/openai/openai-agents-python)** (`openai-agents`) to drive the same MCP servers. Like `ClaudeAgentRunner`, there is no explicit plan — the SDK's built-in agentic loop handles tool discovery, invocation, and multi-turn reasoning autonomously.
-
-### How it works
-
-```
-OpenAIAgentRunner.run(question)
-  │
-  └─ OpenAI Agents SDK Runner.run loop
-       • connects to each MCP server over stdio (MCPServerStdio)
-       • GPT decides which tools to call and in what order
-       • tool calls and results are handled internally by the SDK
-       • final answer is returned via result.final_output
-```
-
-### CLI
-
-After `uv sync`, the `openai-agent` command is available:
-
-```bash
-uv run openai-agent "What sensors are on Chiller 6?"
-```
-
-Flags:
-
-| Flag                  | Description                                                  |
-| --------------------- | ------------------------------------------------------------ |
-| `--model-id MODEL_ID` | OpenAI model ID (default: `gpt-4o`)                         |
-| `--max-turns N`       | Maximum agentic loop turns (default: 30)                     |
-| `--show-trajectory`   | Print each turn's text, tool calls, and token usage          |
-| `--json`              | Output full trajectory (turns, tool calls, token counts) as JSON |
-| `--verbose`           | Show INFO-level logs on stderr                               |
-
-Required env var: `OPENAI_API_KEY`
-
-Examples:
-
-```bash
-# Default model (gpt-4o)
-uv run openai-agent "What assets are at site MAIN?"
-
-# Different model
-uv run openai-agent --model-id gpt-4.1-mini "What sensors are on Chiller 6?"
-
-# Show full trajectory (turns, tool calls, token usage)
-uv run openai-agent --show-trajectory "What are the failure modes for a chiller?"
-
-# Machine-readable trajectory
-uv run openai-agent --json "What is the current time?" | jq .turns
-```
-
-### Python API
-
-```python
-import asyncio
-from agent.openai_agent import OpenAIAgentRunner
-
-runner = OpenAIAgentRunner(model="gpt-4o")
-result = asyncio.run(runner.run("What sensors are on Chiller 6?"))
-print(result.answer)
-```
-
-`AgentResult` fields:
-
-| Field        | Type         | Description                                      |
-| ------------ | ------------ | ------------------------------------------------ |
-| `answer`     | `str`        | Final answer from the agent                      |
-| `trajectory` | `Trajectory` | Full execution trace (turns, tool calls, tokens)  |
-
-`Trajectory` fields:
-
-| Field                 | Type              | Description                          |
-| --------------------- | ----------------- | ------------------------------------ |
-| `turns`               | `list[TurnRecord]`| One record per assistant turn        |
-| `total_input_tokens`  | `int`             | Sum of input tokens across all turns |
-| `total_output_tokens` | `int`             | Sum of output tokens across all turns|
-| `all_tool_calls`      | `list[ToolCall]`  | Flat list of every tool call made    |
-
-Each `TurnRecord` has `index`, `text`, `tool_calls`, `input_tokens`, `output_tokens`.
-Each `ToolCall` has `name`, `input`, `id`, `output`.
-
-```python
-traj = result.trajectory
-print(f"{traj.total_input_tokens} input / {traj.total_output_tokens} output tokens")
-for tc in traj.all_tool_calls:
-    print(f"  {tc.name}: {tc.input}")
-    if tc.output is not None:
-        print(f"    -> {tc.output}")
-```
-
----
-
 ## Connect to Claude Desktop
 
 Add the following to your Claude Desktop `claude_desktop_config.json`:
@@ -702,13 +599,6 @@ uv run pytest src/ -v
 │  ┌─────────────────────────────────────────┐                 │
 │  │  claude-agent-sdk agentic loop          │                 │
 │  │  Claude decides tools + order autonomously               │
-│  │  Trajectory (turns, tool calls, tokens) collected        │
-│  └─────────────────────────────────────────┘                 │
-│                                                              │
-│  OpenAIAgentRunner.run(question)                             │
-│  ┌─────────────────────────────────────────┐                 │
-│  │  openai-agents SDK Runner.run loop      │                 │
-│  │  GPT decides tools + order autonomously                  │
 │  │  Trajectory (turns, tool calls, tokens) collected        │
 │  └─────────────────────────────────────────┘                 │
 └──────────────────────────┬───────────────────────────────────┘

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -130,13 +130,9 @@ uv run vibration-mcp-server
 | `LITELLM_API_KEY`  | _(required)_ | LiteLLM proxy API key                                                |
 | `LITELLM_BASE_URL` | _(required)_ | LiteLLM proxy base URL, e.g. `https://your-litellm-host.example.com` |
 
-**OpenAI** — openai-agent runner
+**OpenAI Agents SDK** — openai-agent runner (always routed through LiteLLM proxy via `litellm_proxy/` prefix)
 
-| Variable         | Default      | Description    |
-| ---------------- | ------------ | -------------- |
-| `OPENAI_API_KEY` | _(required)_ | OpenAI API key |
-
-> **Note:** The `openai-agent` runner also supports LiteLLM proxy via the `litellm_proxy/` model-id prefix — in that case set `LITELLM_API_KEY` and `LITELLM_BASE_URL` instead.
+> Uses the same `LITELLM_API_KEY` and `LITELLM_BASE_URL` variables as the plan-execute runner above.
 
 ---
 
@@ -529,38 +525,26 @@ uv run openai-agent "What sensors are on Chiller 6?"
 
 Flags:
 
-| Flag                  | Description                                                              |
-| --------------------- | ------------------------------------------------------------------------ |
-| `--model-id MODEL_ID` | Model ID, optionally prefixed with `litellm_proxy/` (default: `gpt-4o`) |
-| `--max-turns N`       | Maximum agentic loop turns (default: 30)                                 |
-| `--show-trajectory`   | Print each turn's text, tool calls, and token usage                      |
-| `--json`              | Output full trajectory (turns, tool calls, token counts) as JSON         |
-| `--verbose`           | Show INFO-level logs on stderr                                           |
+| Flag                  | Description                                                                      |
+| --------------------- | -------------------------------------------------------------------------------- |
+| `--model-id MODEL_ID` | LiteLLM model string with `litellm_proxy/` prefix (default: `litellm_proxy/azure/gpt-5.4`) |
+| `--max-turns N`       | Maximum agentic loop turns (default: 30)                                         |
+| `--show-trajectory`   | Print each turn's text, tool calls, and token usage                              |
+| `--json`              | Output full trajectory (turns, tool calls, token counts) as JSON                 |
+| `--verbose`           | Show INFO-level logs on stderr                                                   |
 
-The `--model-id` prefix determines the backend:
-
-| Prefix           | Backend       | Required env vars                     |
-| ---------------- | ------------- | ------------------------------------- |
-| _(none)_         | OpenAI API    | `OPENAI_API_KEY`                      |
-| `litellm_proxy/` | LiteLLM proxy | `LITELLM_API_KEY`, `LITELLM_BASE_URL` |
+Required env vars: `LITELLM_API_KEY`, `LITELLM_BASE_URL`
 
 Examples:
 
 ```bash
-# Direct OpenAI API
-uv run openai-agent "What assets are at site MAIN?"
-
-# Different model
-uv run openai-agent --model-id gpt-4.1-mini "What sensors are on Chiller 6?"
-
-# LiteLLM proxy
-uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 "What sensors are on Chiller 6?"
+uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 "What assets are at site MAIN?"
 
 # Show full trajectory (turns, tool calls, token usage)
-uv run openai-agent --show-trajectory "What are the failure modes for a chiller?"
+uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 --show-trajectory "What are the failure modes for a chiller?"
 
 # Machine-readable trajectory
-uv run openai-agent --json "What is the current time?" | jq .turns
+uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 --json "What is the current time?" | jq .turns
 ```
 
 ### Python API
@@ -569,14 +553,9 @@ uv run openai-agent --json "What is the current time?" | jq .turns
 import asyncio
 from agent.openai_agent import OpenAIAgentRunner
 
-# Direct OpenAI API
-runner = OpenAIAgentRunner(model="gpt-4o")
-result = asyncio.run(runner.run("What sensors are on Chiller 6?"))
-print(result.answer)
-
-# Via LiteLLM proxy
 runner = OpenAIAgentRunner(model="litellm_proxy/azure/gpt-5.4")
 result = asyncio.run(runner.run("What sensors are on Chiller 6?"))
+print(result.answer)
 ```
 
 `AgentResult` fields:

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -14,22 +14,16 @@ This directory contains the MCP servers and infrastructure for the AssetOpsBench
   - [tsfm](#tsfm)
   - [wo](#wo)
   - [vibration](#vibration)
+- [Example queries](#example-queries)
 - [Plan-Execute Agent](#plan-execute-agent)
   - [How it works](#how-it-works)
   - [CLI](#cli)
-  - [End-to-end example](#end-to-end-example)
-  - [Python API](#python-api)
-  - [Bring your own LLM](#bring-your-own-llm)
-  - [Add more MCP servers](#add-more-mcp-servers)
 - [Claude Agent](#claude-agent)
   - [How it works](#how-it-works-1)
   - [CLI](#cli-1)
-  - [Python API](#python-api-1)
 - [OpenAI Agent](#openai-agent)
   - [How it works](#how-it-works-2)
   - [CLI](#cli-2)
-  - [Python API](#python-api-2)
-- [Connect to Claude Desktop](#connect-to-claude-desktop)
 - [Running Tests](#running-tests)
 - [Architecture](#architecture)
 
@@ -223,6 +217,22 @@ uv run vibration-mcp-server
 
 ---
 
+## Example queries
+
+The CLI examples below use a `$query` shell variable so you can swap in any question without editing the commands. Pick one of these to get started:
+
+```bash
+# Simple single-server queries
+query="What assets are at site MAIN?"
+query="What sensors are on Chiller 6?"
+query="What is the current time?"
+
+# Multi-step / multi-server queries
+query="What are the failure modes for a chiller?"
+query="How many work orders does equipment CWC04014 have, and what is the most common failure code?"
+query="For equipment CWC04013, how many preventive vs corrective work orders were completed?"
+```
+
 ## Plan-Execute Agent
 
 `src/agent/` is a custom MCP client that implements a **plan-and-execute** workflow over the MCP servers. It replaces AgentHive's bespoke orchestration with the standard MCP protocol.
@@ -250,7 +260,7 @@ PlanExecuteRunner.run(question)
 After `uv sync`, the `plan-execute` command is available:
 
 ```bash
-uv run plan-execute "What assets are available at site MAIN?"
+uv run plan-execute "$query"
 ```
 
 > **Note:** `plan-execute` spawns MCP servers on-demand for each query — you do **not** need to start them manually first. Servers are launched as subprocesses, used, then exit automatically.
@@ -276,128 +286,17 @@ Examples:
 
 ```bash
 # WatsonX — default model
-uv run plan-execute "What assets are at site MAIN?"
+uv run plan-execute "$query"
 
 # WatsonX — different model, inspect the plan
-uv run plan-execute --model-id watsonx/ibm/granite-3-3-8b-instruct --show-plan "List sensors for asset CH-1"
+uv run plan-execute --model-id watsonx/ibm/granite-3-3-8b-instruct --show-plan "$query"
 
 # LiteLLM proxy
-uv run plan-execute --model-id litellm_proxy/GCP/claude-4-sonnet "What are the failure modes for a chiller?"
+uv run plan-execute --model-id litellm_proxy/GCP/claude-4-sonnet "$query"
 
 # Machine-readable output
-uv run plan-execute --show-trajectory --json "How many observations exist for CH-1?" | jq .answer
+uv run plan-execute --show-trajectory --json "$query" | jq .answer
 ```
-
-### End-to-end examples
-
-All six servers (iot, utilities, fmsr, tsfm, wo, vibration) are registered by default.
-
-#### Work order queries (requires CouchDB + populated `workorder` db)
-
-Equipment IDs in the sample dataset: `CWC04014` (524 WOs), `CWC04013` (431 WOs), `CWC04009` (alert events).
-
-```bash
-# Work order count and most common failure code
-uv run plan-execute "How many work orders does equipment CWC04014 have, and what is the most common failure code?"
-
-# Preventive vs corrective split
-uv run plan-execute "For equipment CWC04013, how many preventive vs corrective work orders were completed?"
-
-# Alert-to-failure probability
-uv run plan-execute "What is the probability that alert rule RUL0018 on equipment CWC04009 leads to a work order, and how long does it typically take?"
-
-# Work order distribution + next prediction (multi-step)
-uv run plan-execute --show-plan --show-trajectory \
-  "For equipment CWC04014, show the work order distribution and predict the next maintenance type"
-```
-
-#### Multi-server parallel query
-
-Run a question that exercises three servers with independent parallel steps:
-
-```bash
-uv run plan-execute --show-plan --show-trajectory \
-  "What is the current date and time? Also list assets at site MAIN. Also get sensor list and failure mode list for any of the chiller at site MAIN."
-```
-
-Expected plan (3 parallel steps, no dependencies):
-
-```
-[1] utilities  : current_date_time()
-[2] iot        : assets(site_name="MAIN")
-[3] fmsr       : get_failure_modes(asset_name="chiller")
-```
-
-Expected execution output (trimmed):
-
-```
-[OK] Step 1 (utilities)
-     {"currentDateTime": "2026-02-20T17:28:39Z", "currentDateTimeDescription": "Today's date is 2026-02-20 and time is 17:28:39."}
-
-[OK] Step 2 (iot)
-     {"site_name": "MAIN", "total_assets": 1, "assets": ["Chiller 6"], "message": "found 1 assets for site_name MAIN."}
-
-[OK] Step 3 (fmsr)
-     {"asset_name": "chiller", "failure_modes": ["Compressor Overheating: Failed due to Normal wear, overheating", ...]}
-```
-
-> **Note:** Curated assets (`chiller`, `ahu`) are served from `failure_modes.yaml` without any LLM call.
-
-### Python API
-
-```python
-import asyncio
-from agent import PlanExecuteRunner
-from llm import LiteLLMBackend
-
-runner = PlanExecuteRunner(llm=LiteLLMBackend("watsonx/meta-llama/llama-3-3-70b-instruct"))
-result = asyncio.run(runner.run("What assets are available at site MAIN?"))
-print(result.answer)
-```
-
-`OrchestratorResult` fields:
-
-| Field     | Type               | Description                       |
-| --------- | ------------------ | --------------------------------- |
-| `answer`  | `str`              | Final synthesised answer          |
-| `plan`    | `Plan`             | The generated plan with its steps |
-| `trajectory` | `list[StepResult]` | Per-step execution results        |
-
-### Bring your own LLM
-
-Implement `LLMBackend` to use any model:
-
-```python
-from llm import LLMBackend
-
-class MyLLM(LLMBackend):
-    def generate(self, prompt: str, temperature: float = 0.0) -> str:
-        ...  # call your model here
-
-runner = PlanExecuteRunner(llm=MyLLM())
-```
-
-### Add more MCP servers
-
-Pass `server_paths` to register additional servers. Keys must match the server names the planner assigns steps to:
-
-```python
-from agent import PlanExecuteRunner
-
-runner = PlanExecuteRunner(
-    llm=my_llm,
-    server_paths={
-        "iot":       "iot-mcp-server",
-        "utilities": "utilities-mcp-server",
-        "fmsr":      "fmsr-mcp-server",
-        "tsfm":      "tsfm-mcp-server",
-        "wo":        "wo-mcp-server",
-        "vibration": "vibration-mcp-server",
-    },
-)
-```
-
-> **Note:** passing `server_paths` replaces the defaults entirely. Include all servers you need.
 
 ---
 
@@ -422,7 +321,7 @@ ClaudeAgentRunner.run(question)
 After `uv sync`, the `claude-agent` command is available:
 
 ```bash
-uv run claude-agent "What sensors are on Chiller 6?"
+uv run claude-agent "$query"
 ```
 
 Flags:
@@ -446,55 +345,16 @@ Examples:
 
 ```bash
 # Direct Anthropic API
-uv run claude-agent "What assets are at site MAIN?"
+uv run claude-agent "$query"
 
 # LiteLLM proxy
-uv run claude-agent --model-id litellm_proxy/aws/claude-opus-4-6 "What sensors are on Chiller 6?"
+uv run claude-agent --model-id litellm_proxy/aws/claude-opus-4-6 "$query"
 
 # Show full trajectory (turns, tool calls, token usage)
-uv run claude-agent --show-trajectory "What are the failure modes for a chiller?"
+uv run claude-agent --show-trajectory "$query"
 
 # Machine-readable trajectory
-uv run claude-agent --json "What is the current time?" | jq .turns
-```
-
-### Python API
-
-```python
-import anyio
-from agent.claude_agent import ClaudeAgentRunner
-
-runner = ClaudeAgentRunner(model="litellm_proxy/aws/claude-opus-4-6")
-result = anyio.run(runner.run, "What sensors are on Chiller 6?")
-print(result.answer)
-```
-
-`AgentResult` fields:
-
-| Field     | Type         | Description                                    |
-| --------- | ------------ | ---------------------------------------------- |
-| `answer`  | `str`        | Final answer from the agent                    |
-| `trajectory` | `Trajectory` | Full execution trace (turns, tool calls, tokens) |
-
-`Trajectory` fields:
-
-| Field                 | Type              | Description                          |
-| --------------------- | ----------------- | ------------------------------------ |
-| `turns`               | `list[TurnRecord]`| One record per assistant turn        |
-| `total_input_tokens`  | `int`             | Sum of input tokens across all turns |
-| `total_output_tokens` | `int`             | Sum of output tokens across all turns|
-| `all_tool_calls`      | `list[ToolCall]`  | Flat list of every tool call made    |
-
-Each `TurnRecord` has `index`, `text`, `tool_calls`, `input_tokens`, `output_tokens`.
-Each `ToolCall` has `name`, `input`, `id`, `output` (the MCP server response, captured via `PostToolUse` hook).
-
-```python
-traj = result.trajectory
-print(f"{traj.total_input_tokens} input / {traj.total_output_tokens} output tokens")
-for tc in traj.all_tool_calls:
-    print(f"  {tc.name}: {tc.input}")
-    if tc.output is not None:
-        print(f"    -> {tc.output}")
+uv run claude-agent --json "$query" | jq .turns
 ```
 
 ---
@@ -520,7 +380,7 @@ OpenAIAgentRunner.run(question)
 After `uv sync`, the `openai-agent` command is available:
 
 ```bash
-uv run openai-agent "What sensors are on Chiller 6?"
+uv run openai-agent "$query"
 ```
 
 Flags:
@@ -538,94 +398,13 @@ Required env vars: `LITELLM_API_KEY`, `LITELLM_BASE_URL`
 Examples:
 
 ```bash
-uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 "What assets are at site MAIN?"
+uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 "$query"
 
 # Show full trajectory (turns, tool calls, token usage)
-uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 --show-trajectory "What are the failure modes for a chiller?"
+uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 --show-trajectory "$query"
 
 # Machine-readable trajectory
-uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 --json "What is the current time?" | jq .turns
-```
-
-### Python API
-
-```python
-import asyncio
-from agent.openai_agent import OpenAIAgentRunner
-
-runner = OpenAIAgentRunner(model="litellm_proxy/azure/gpt-5.4")
-result = asyncio.run(runner.run("What sensors are on Chiller 6?"))
-print(result.answer)
-```
-
-`AgentResult` fields:
-
-| Field        | Type         | Description                                      |
-| ------------ | ------------ | ------------------------------------------------ |
-| `answer`     | `str`        | Final answer from the agent                      |
-| `trajectory` | `Trajectory` | Full execution trace (turns, tool calls, tokens)  |
-
-`Trajectory` fields:
-
-| Field                 | Type              | Description                          |
-| --------------------- | ----------------- | ------------------------------------ |
-| `turns`               | `list[TurnRecord]`| One record per assistant turn        |
-| `total_input_tokens`  | `int`             | Sum of input tokens across all turns |
-| `total_output_tokens` | `int`             | Sum of output tokens across all turns|
-| `all_tool_calls`      | `list[ToolCall]`  | Flat list of every tool call made    |
-
-Each `TurnRecord` has `index`, `text`, `tool_calls`, `input_tokens`, `output_tokens`.
-Each `ToolCall` has `name`, `input`, `id`, `output`.
-
-```python
-traj = result.trajectory
-print(f"{traj.total_input_tokens} input / {traj.total_output_tokens} output tokens")
-for tc in traj.all_tool_calls:
-    print(f"  {tc.name}: {tc.input}")
-    if tc.output is not None:
-        print(f"    -> {tc.output}")
-```
-
----
-
-## Connect to Claude Desktop
-
-Add the following to your Claude Desktop `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "utilities": {
-      "command": "/path/to/uv",
-      "args": [
-        "run",
-        "--project",
-        "/path/to/AssetOpsBench",
-        "utilities-mcp-server"
-      ]
-    },
-    "iot": {
-      "command": "/path/to/uv",
-      "args": ["run", "--project", "/path/to/AssetOpsBench", "iot-mcp-server"]
-    },
-    "fmsr": {
-      "command": "/path/to/uv",
-      "args": ["run", "--project", "/path/to/AssetOpsBench", "fmsr-mcp-server"]
-    },
-    "tsfm": {
-      "command": "/path/to/uv",
-      "args": ["run", "--project", "/path/to/AssetOpsBench", "tsfm-mcp-server"]
-    },
-    "wo": {
-      "command": "/path/to/uv",
-      "args": ["run", "--project", "/path/to/AssetOpsBench", "wo-mcp-server"]
-    },
-    "vibration": {
-      "command": "/path/to/uv",
-      "args": ["run", "--project", "/path/to/AssetOpsBench", "vibration-mcp-server"]
-    }
-  }
-}
+uv run openai-agent --model-id litellm_proxy/azure/gpt-5.4 --json "$query" | jq .turns
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pyyaml>=6.0",
     "litellm==1.81.13",
     "claude-agent-sdk>=0.0.14",
+    "openai-agents>=0.0.7",
     "python-dotenv>=1.0",
     "scipy>=1.10.0",
 ]
@@ -36,6 +37,7 @@ fmsr-mcp-server = "servers.fmsr.main:main"
 tsfm-mcp-server = "servers.tsfm.main:main"
 wo-mcp-server = "servers.wo.main:main"
 vibration-mcp-server = "servers.vibration.main:main"
+openai-agent = "agent.openai_agent.cli:main"
 
 
 [dependency-groups]

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -5,6 +5,7 @@ from .models import AgentResult
 from .plan_execute.runner import PlanExecuteRunner
 from .plan_execute.models import OrchestratorResult, Plan, PlanStep, StepResult
 from .claude_agent.runner import ClaudeAgentRunner
+from .openai_agent.runner import OpenAIAgentRunner
 
 __all__ = [
     "AgentRunner",
@@ -15,4 +16,5 @@ __all__ = [
     "PlanStep",
     "StepResult",
     "ClaudeAgentRunner",
+    "OpenAIAgentRunner",
 ]

--- a/src/agent/claude_agent/cli.py
+++ b/src/agent/claude_agent/cli.py
@@ -16,7 +16,7 @@ import json
 import logging
 import sys
 
-_DEFAULT_MODEL = "claude-opus-4-6"
+_DEFAULT_MODEL = "litellm_proxy/aws/claude-opus-4-6"
 _LOG_FORMAT = "%(asctime)s  %(levelname)-8s  %(name)s  %(message)s"
 _LOG_DATE_FORMAT = "%H:%M:%S"
 _HR = "─" * 60

--- a/src/agent/claude_agent/runner.py
+++ b/src/agent/claude_agent/runner.py
@@ -29,7 +29,7 @@ from ..runner import AgentRunner
 
 _log = logging.getLogger(__name__)
 
-_DEFAULT_MODEL = "claude-opus-4-6"
+_DEFAULT_MODEL = "litellm_proxy/aws/claude-opus-4-6"
 _LITELLM_PREFIX = "litellm_proxy/"
 
 
@@ -102,7 +102,7 @@ class ClaudeAgentRunner(AgentRunner):
              Accepted for interface compatibility with ``AgentRunner``.
         server_paths: MCP server specs identical to ``PlanExecuteRunner``.
                       Defaults to all registered servers.
-        model: Claude model ID to use (default: ``claude-opus-4-6``).
+        model: Claude model ID to use (default: ``litellm_proxy/aws/claude-opus-4-6``).
         max_turns: Maximum agentic loop turns (default: 30).
         permission_mode: claude-agent-sdk permission mode (default: ``"default"``).
     """

--- a/src/agent/claude_agent/tests/test_runner.py
+++ b/src/agent/claude_agent/tests/test_runner.py
@@ -85,7 +85,7 @@ def test_build_mcp_servers_empty():
 
 def test_runner_defaults():
     runner = ClaudeAgentRunner()
-    assert runner._model == "claude-opus-4-6"
+    assert runner._model == "aws/claude-opus-4-6"
     assert runner._max_turns == 30
     assert runner._permission_mode == "bypassPermissions"
     assert "iot" in runner._resolved_server_paths

--- a/src/agent/openai_agent/__init__.py
+++ b/src/agent/openai_agent/__init__.py
@@ -1,0 +1,6 @@
+"""OpenAI Agents SDK runner subpackage."""
+
+from .models import ToolCall, Trajectory, TurnRecord
+from .runner import OpenAIAgentRunner
+
+__all__ = ["OpenAIAgentRunner", "Trajectory", "TurnRecord", "ToolCall"]

--- a/src/agent/openai_agent/cli.py
+++ b/src/agent/openai_agent/cli.py
@@ -3,6 +3,7 @@
 Usage:
     openai-agent "What sensors are on Chiller 6?"
     openai-agent --model-id gpt-4o --max-turns 20 "List failure modes for pumps"
+    openai-agent --model-id litellm_proxy/Azure/gpt-5-2025-08-07 "What sensors are on Chiller 6?"
     openai-agent --show-trajectory "What sensors are on Chiller 6?"
     openai-agent --json "What is the current time?"
 """
@@ -28,12 +29,21 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Run a question through the OpenAI Agents SDK with AssetOpsBench MCP servers.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=f"""
+model-id format:
+  The provider is encoded in the model-id prefix:
+    gpt-4o                           OpenAI API directly
+    litellm_proxy/<model>            LiteLLM proxy (e.g. litellm_proxy/Azure/gpt-5-2025-08-07)
+
 environment variables:
-  OPENAI_API_KEY        OpenAI API key (required)
+  OPENAI_API_KEY        OpenAI API key          (required for direct OpenAI models)
+
+  LITELLM_API_KEY       LiteLLM API key         (required for litellm_proxy/* models)
+  LITELLM_BASE_URL      LiteLLM base URL        (required for litellm_proxy/* models)
 
 examples:
   openai-agent "What assets are at site MAIN?"
   openai-agent --model-id gpt-4o --max-turns 20 "List sensors on Chiller 6"
+  openai-agent --model-id litellm_proxy/Azure/gpt-5-2025-08-07 "What sensors are on Chiller 6?"
   openai-agent --show-trajectory "What sensors are on Chiller 6?"
   openai-agent --json "What is the current time?"
 """,
@@ -43,7 +53,7 @@ examples:
         "--model-id",
         default=_DEFAULT_MODEL,
         metavar="MODEL_ID",
-        help=f"OpenAI model ID (default: {_DEFAULT_MODEL}).",
+        help=f"Model ID, optionally prefixed with litellm_proxy/ (default: {_DEFAULT_MODEL}).",
     )
     parser.add_argument(
         "--max-turns",

--- a/src/agent/openai_agent/cli.py
+++ b/src/agent/openai_agent/cli.py
@@ -1,11 +1,10 @@
 """CLI entry point for the OpenAIAgentRunner.
 
 Usage:
-    openai-agent "What sensors are on Chiller 6?"
-    openai-agent --model-id gpt-4o --max-turns 20 "List failure modes for pumps"
-    openai-agent --model-id litellm_proxy/Azure/gpt-5-2025-08-07 "What sensors are on Chiller 6?"
-    openai-agent --show-trajectory "What sensors are on Chiller 6?"
-    openai-agent --json "What is the current time?"
+    openai-agent --model-id litellm_proxy/azure/gpt-5.4 "What sensors are on Chiller 6?"
+    openai-agent --model-id litellm_proxy/azure/gpt-5.4 --max-turns 20 "List failure modes for pumps"
+    openai-agent --model-id litellm_proxy/azure/gpt-5.4 --show-trajectory "What sensors are on Chiller 6?"
+    openai-agent --model-id litellm_proxy/azure/gpt-5.4 --json "What is the current time?"
 """
 
 from __future__ import annotations
@@ -17,7 +16,7 @@ import json
 import logging
 import sys
 
-_DEFAULT_MODEL = "gpt-4o"
+_DEFAULT_MODEL = "litellm_proxy/azure/gpt-5.4"
 _LOG_FORMAT = "%(asctime)s  %(levelname)-8s  %(name)s  %(message)s"
 _LOG_DATE_FORMAT = "%H:%M:%S"
 _HR = "─" * 60
@@ -30,21 +29,16 @@ def _build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=f"""
 model-id format:
-  The provider is encoded in the model-id prefix:
-    gpt-4o                           OpenAI API directly
-    litellm_proxy/<model>            LiteLLM proxy (e.g. litellm_proxy/Azure/gpt-5-2025-08-07)
+  litellm_proxy/<model>   LiteLLM proxy (e.g. litellm_proxy/azure/gpt-5.4)
 
 environment variables:
-  OPENAI_API_KEY        OpenAI API key          (required for direct OpenAI models)
-
-  LITELLM_API_KEY       LiteLLM API key         (required for litellm_proxy/* models)
-  LITELLM_BASE_URL      LiteLLM base URL        (required for litellm_proxy/* models)
+  LITELLM_API_KEY       LiteLLM API key    (required)
+  LITELLM_BASE_URL      LiteLLM base URL   (required)
 
 examples:
   openai-agent "What assets are at site MAIN?"
-  openai-agent --model-id gpt-4o --max-turns 20 "List sensors on Chiller 6"
-  openai-agent --model-id litellm_proxy/Azure/gpt-5-2025-08-07 "What sensors are on Chiller 6?"
-  openai-agent --show-trajectory "What sensors are on Chiller 6?"
+  openai-agent --model-id litellm_proxy/azure/gpt-5.4 --max-turns 20 "List sensors on Chiller 6"
+  openai-agent --show-trajectory "What are the failure modes for a chiller?"
   openai-agent --json "What is the current time?"
 """,
     )
@@ -53,7 +47,7 @@ examples:
         "--model-id",
         default=_DEFAULT_MODEL,
         metavar="MODEL_ID",
-        help=f"Model ID, optionally prefixed with litellm_proxy/ (default: {_DEFAULT_MODEL}).",
+        help=f"LiteLLM model string with litellm_proxy/ prefix (default: {_DEFAULT_MODEL}).",
     )
     parser.add_argument(
         "--max-turns",

--- a/src/agent/openai_agent/cli.py
+++ b/src/agent/openai_agent/cli.py
@@ -1,0 +1,135 @@
+"""CLI entry point for the OpenAIAgentRunner.
+
+Usage:
+    openai-agent "What sensors are on Chiller 6?"
+    openai-agent --model-id gpt-4o --max-turns 20 "List failure modes for pumps"
+    openai-agent --show-trajectory "What sensors are on Chiller 6?"
+    openai-agent --json "What is the current time?"
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import dataclasses
+import json
+import logging
+import sys
+
+_DEFAULT_MODEL = "gpt-4o"
+_LOG_FORMAT = "%(asctime)s  %(levelname)-8s  %(name)s  %(message)s"
+_LOG_DATE_FORMAT = "%H:%M:%S"
+_HR = "─" * 60
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="openai-agent",
+        description="Run a question through the OpenAI Agents SDK with AssetOpsBench MCP servers.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""
+environment variables:
+  OPENAI_API_KEY        OpenAI API key (required)
+
+examples:
+  openai-agent "What assets are at site MAIN?"
+  openai-agent --model-id gpt-4o --max-turns 20 "List sensors on Chiller 6"
+  openai-agent --show-trajectory "What sensors are on Chiller 6?"
+  openai-agent --json "What is the current time?"
+""",
+    )
+    parser.add_argument("question", help="The question to answer.")
+    parser.add_argument(
+        "--model-id",
+        default=_DEFAULT_MODEL,
+        metavar="MODEL_ID",
+        help=f"OpenAI model ID (default: {_DEFAULT_MODEL}).",
+    )
+    parser.add_argument(
+        "--max-turns",
+        type=int,
+        default=30,
+        metavar="N",
+        help="Maximum agentic loop turns (default: 30).",
+    )
+    parser.add_argument(
+        "--show-trajectory",
+        action="store_true",
+        help="Print each turn's text, tool calls, and token usage.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="output_json",
+        help="Output the full result as JSON.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show INFO-level logs on stderr.",
+    )
+    return parser
+
+
+def _setup_logging(verbose: bool) -> None:
+    level = logging.INFO if verbose else logging.WARNING
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATE_FORMAT))
+    logging.root.handlers.clear()
+    logging.root.addHandler(handler)
+    logging.root.setLevel(level)
+
+
+def _print_trace(trajectory) -> None:
+    print(f"\n{_HR}")
+    print("  Trace")
+    print(_HR)
+    for turn in trajectory.turns:
+        print(f"\n  [Turn {turn.index}]  "
+              f"in={turn.input_tokens} out={turn.output_tokens} tokens")
+        if turn.text:
+            snippet = turn.text[:200] + ("..." if len(turn.text) > 200 else "")
+            print(f"    text: {snippet}")
+        for tc in turn.tool_calls:
+            print(f"    tool: {tc.name}  input: {tc.input}")
+            if tc.output is not None:
+                out_str = str(tc.output)
+                snippet = out_str[:200] + ("..." if len(out_str) > 200 else "")
+                print(f"    output: {snippet}")
+    print(f"\n  Total: {trajectory.total_input_tokens} input / "
+          f"{trajectory.total_output_tokens} output tokens  "
+          f"({len(trajectory.turns)} turns, "
+          f"{len(trajectory.all_tool_calls)} tool calls)")
+
+
+async def _run(args: argparse.Namespace) -> None:
+    from agent.openai_agent.runner import OpenAIAgentRunner
+
+    runner = OpenAIAgentRunner(model=args.model_id, max_turns=args.max_turns)
+    result = await runner.run(args.question)
+
+    if args.output_json:
+        print(json.dumps(dataclasses.asdict(result.trajectory), indent=2))
+        return
+
+    if args.show_trajectory:
+        _print_trace(result.trajectory)
+
+    print(f"\n{_HR}")
+    print("  Answer")
+    print(_HR)
+    print(result.answer)
+    print()
+
+
+def main() -> None:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+    args = _build_parser().parse_args()
+    _setup_logging(args.verbose)
+    asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent/openai_agent/models.py
+++ b/src/agent/openai_agent/models.py
@@ -1,0 +1,45 @@
+"""Trajectory data models for OpenAIAgentRunner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class ToolCall:
+    """A single tool invocation made by the agent."""
+
+    name: str
+    input: dict
+    id: str = ""
+    output: object = None
+
+
+@dataclass
+class TurnRecord:
+    """One item group: text output, tool calls, and token usage."""
+
+    index: int
+    text: str
+    tool_calls: list[ToolCall] = field(default_factory=list)
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+@dataclass
+class Trajectory:
+    """Full execution trace across all agent turns."""
+
+    turns: list[TurnRecord] = field(default_factory=list)
+
+    @property
+    def total_input_tokens(self) -> int:
+        return sum(t.input_tokens for t in self.turns)
+
+    @property
+    def total_output_tokens(self) -> int:
+        return sum(t.output_tokens for t in self.turns)
+
+    @property
+    def all_tool_calls(self) -> list[ToolCall]:
+        return [tc for turn in self.turns for tc in turn.tool_calls]

--- a/src/agent/openai_agent/runner.py
+++ b/src/agent/openai_agent/runner.py
@@ -11,6 +11,10 @@ Usage::
     runner = OpenAIAgentRunner(model="gpt-4o")
     result = anyio.run(runner.run, "What sensors are on Chiller 6?")
     print(result.answer)
+
+    # Via LiteLLM proxy:
+    runner = OpenAIAgentRunner(model="litellm_proxy/Azure/gpt-5-2025-08-07")
+    result = anyio.run(runner.run, "What sensors are on Chiller 6?")
 """
 
 from __future__ import annotations
@@ -20,7 +24,9 @@ import logging
 import os
 from pathlib import Path
 
-from agents import Agent, Runner
+from openai import AsyncOpenAI
+
+from agents import Agent, ModelProvider, OpenAIChatCompletionsModel, RunConfig, Runner, set_tracing_disabled
 from agents.mcp import MCPServerStdio
 
 from ..models import AgentResult
@@ -31,6 +37,55 @@ from .models import ToolCall, Trajectory, TurnRecord
 _log = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "gpt-4o"
+_LITELLM_PREFIX = "litellm_proxy/"
+
+def _resolve_model(model_id: str) -> str:
+    """Strip the ``litellm_proxy/`` prefix from a model ID.
+
+    Examples::
+
+        "litellm_proxy/Azure/gpt-5-2025-08-07"  ->  "Azure/gpt-5-2025-08-07"
+        "gpt-4o"                                 ->  "gpt-4o"
+    """
+    if model_id.startswith(_LITELLM_PREFIX):
+        return model_id[len(_LITELLM_PREFIX):]
+    return model_id
+
+
+def _build_run_config(model_id: str) -> RunConfig | None:
+    """Build a RunConfig with a LiteLLM model provider when needed.
+
+    When *model_id* starts with ``litellm_proxy/``, creates an
+    :class:`AsyncOpenAI` client pointing at the LiteLLM proxy (using
+    ``LITELLM_BASE_URL`` and ``LITELLM_API_KEY``) and wraps it in
+    :class:`OpenAIChatCompletionsModel`.
+
+    Returns ``None`` for direct OpenAI API usage.
+    """
+    if not model_id.startswith(_LITELLM_PREFIX):
+        return None
+
+    base_url = os.environ.get("LITELLM_BASE_URL")
+    api_key = os.environ.get("LITELLM_API_KEY")
+    if not base_url or not api_key:
+        raise ValueError(
+            "LITELLM_BASE_URL and LITELLM_API_KEY must be set "
+            f"when using {_LITELLM_PREFIX!r} model prefix"
+        )
+
+    resolved = _resolve_model(model_id)
+    client = AsyncOpenAI(base_url=base_url, api_key=api_key)
+    set_tracing_disabled(disabled=True)
+
+    class _LiteLLMModelProvider(ModelProvider):
+        def get_model(self, model_name: str | None):
+            return OpenAIChatCompletionsModel(
+                model=model_name or resolved,
+                openai_client=client,
+            )
+
+    return RunConfig(model_provider=_LiteLLMModelProvider())
+
 
 _SYSTEM_PROMPT = """\
 You are an industrial asset operations assistant with access to MCP tools for
@@ -141,12 +196,18 @@ class OpenAIAgentRunner(AgentRunner):
     The SDK handles tool discovery, invocation, and multi-turn conversation
     against the registered MCP servers.
 
+    Supports direct OpenAI API and LiteLLM proxy routing via model ID prefix:
+    - ``gpt-4o`` → direct OpenAI API (requires ``OPENAI_API_KEY``)
+    - ``litellm_proxy/Azure/gpt-5-2025-08-07`` → LiteLLM proxy
+      (requires ``LITELLM_BASE_URL`` and ``LITELLM_API_KEY``)
+
     Args:
         llm: Unused — OpenAIAgentRunner uses the OpenAI Agents SDK directly.
              Accepted for interface compatibility with ``AgentRunner``.
         server_paths: MCP server specs identical to ``PlanExecuteRunner``.
                       Defaults to all registered servers.
-        model: OpenAI model ID to use (default: ``gpt-4o``).
+        model: Model ID, optionally prefixed with ``litellm_proxy/``
+               (default: ``gpt-4o``).
         max_turns: Maximum agentic loop turns (default: 30).
     """
 
@@ -158,7 +219,9 @@ class OpenAIAgentRunner(AgentRunner):
         max_turns: int = 30,
     ) -> None:
         super().__init__(llm, server_paths)
-        self._model = model
+        self._model_id = model
+        self._model = _resolve_model(model)
+        self._run_config = _build_run_config(model)
         self._max_turns = max_turns
         self._resolved_server_paths: dict[str, Path | str] = (
             server_paths if server_paths is not None else dict(DEFAULT_SERVER_PATHS)
@@ -190,10 +253,14 @@ class OpenAIAgentRunner(AgentRunner):
                 len(active_servers),
             )
 
+            run_kwargs: dict = dict(max_turns=self._max_turns)
+            if self._run_config is not None:
+                run_kwargs["run_config"] = self._run_config
+
             result = await Runner.run(
                 agent,
                 question,
-                max_turns=self._max_turns,
+                **run_kwargs,
             )
 
             answer = result.final_output or ""

--- a/src/agent/openai_agent/runner.py
+++ b/src/agent/openai_agent/runner.py
@@ -8,13 +8,9 @@ Usage::
     import anyio
     from agent.openai_agent import OpenAIAgentRunner
 
-    runner = OpenAIAgentRunner(model="gpt-4o")
+    runner = OpenAIAgentRunner(model="litellm_proxy/azure/gpt-5.4")
     result = anyio.run(runner.run, "What sensors are on Chiller 6?")
     print(result.answer)
-
-    # Via LiteLLM proxy:
-    runner = OpenAIAgentRunner(model="litellm_proxy/Azure/gpt-5-2025-08-07")
-    result = anyio.run(runner.run, "What sensors are on Chiller 6?")
 """
 
 from __future__ import annotations
@@ -36,7 +32,7 @@ from .models import ToolCall, Trajectory, TurnRecord
 
 _log = logging.getLogger(__name__)
 
-_DEFAULT_MODEL = "gpt-4o"
+_DEFAULT_MODEL = "litellm_proxy/azure/gpt-5.4"
 _LITELLM_PREFIX = "litellm_proxy/"
 
 def _resolve_model(model_id: str) -> str:
@@ -196,18 +192,16 @@ class OpenAIAgentRunner(AgentRunner):
     The SDK handles tool discovery, invocation, and multi-turn conversation
     against the registered MCP servers.
 
-    Supports direct OpenAI API and LiteLLM proxy routing via model ID prefix:
-    - ``gpt-4o`` → direct OpenAI API (requires ``OPENAI_API_KEY``)
-    - ``litellm_proxy/Azure/gpt-5-2025-08-07`` → LiteLLM proxy
-      (requires ``LITELLM_BASE_URL`` and ``LITELLM_API_KEY``)
+    Routes all requests through a LiteLLM proxy via the ``litellm_proxy/``
+    model ID prefix (requires ``LITELLM_BASE_URL`` and ``LITELLM_API_KEY``).
 
     Args:
         llm: Unused — OpenAIAgentRunner uses the OpenAI Agents SDK directly.
              Accepted for interface compatibility with ``AgentRunner``.
         server_paths: MCP server specs identical to ``PlanExecuteRunner``.
                       Defaults to all registered servers.
-        model: Model ID, optionally prefixed with ``litellm_proxy/``
-               (default: ``gpt-4o``).
+        model: LiteLLM model string with ``litellm_proxy/`` prefix
+               (default: ``litellm_proxy/azure/gpt-5.4``).
         max_turns: Maximum agentic loop turns (default: 30).
     """
 

--- a/src/agent/openai_agent/runner.py
+++ b/src/agent/openai_agent/runner.py
@@ -1,0 +1,235 @@
+"""AgentRunner implementation backed by the OpenAI Agents SDK.
+
+Each registered MCP server is connected as a stdio MCP server so the OpenAI
+agent can call IoT / FMSR / TSFM / utilities tools directly via MCP.
+
+Usage::
+
+    import anyio
+    from agent.openai_agent import OpenAIAgentRunner
+
+    runner = OpenAIAgentRunner(model="gpt-4o")
+    result = anyio.run(runner.run, "What sensors are on Chiller 6?")
+    print(result.answer)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+from agents import Agent, Runner
+from agents.mcp import MCPServerStdio
+
+from ..models import AgentResult
+from ..plan_execute.executor import DEFAULT_SERVER_PATHS
+from ..runner import AgentRunner
+from .models import ToolCall, Trajectory, TurnRecord
+
+_log = logging.getLogger(__name__)
+
+_DEFAULT_MODEL = "gpt-4o"
+
+_SYSTEM_PROMPT = """\
+You are an industrial asset operations assistant with access to MCP tools for
+querying IoT sensor data, failure mode and symptom records, time-series
+forecasting models, and work order management.
+
+Answer the user's question concisely and accurately using the available tools.
+When you retrieve data, include the key numbers or names in your answer.
+"""
+
+
+def _build_mcp_servers(
+    server_paths: dict[str, Path | str],
+) -> list[MCPServerStdio]:
+    """Convert server_paths entries into MCPServerStdio instances.
+
+    Entry-point names (str without path separators) become
+    ``MCPServerStdio(command="uv", args=["run", name])``.
+    Path objects become ``MCPServerStdio(command="uv", args=["run", str(path)])``.
+    """
+    servers: list[MCPServerStdio] = []
+    for name, spec in server_paths.items():
+        cmd_arg = str(spec) if isinstance(spec, Path) else spec
+        servers.append(
+            MCPServerStdio(
+                name=name,
+                params={
+                    "command": "uv",
+                    "args": ["run", cmd_arg],
+                },
+                cache_tools_list=True,
+            )
+        )
+    return servers
+
+
+def _build_trajectory(result) -> Trajectory:
+    """Extract a Trajectory from a Runner.run result.
+
+    Walks ``result.new_items`` to collect text messages, tool calls, and
+    tool outputs.  Token usage is pulled from ``result.raw_responses``.
+    """
+    trajectory = Trajectory()
+    turn_index = 0
+    text_parts: list[str] = []
+    tool_calls: list[ToolCall] = []
+
+    def _flush() -> None:
+        nonlocal text_parts, tool_calls, turn_index
+        if not text_parts and not tool_calls:
+            return
+        trajectory.turns.append(
+            TurnRecord(
+                index=turn_index,
+                text="".join(text_parts),
+                tool_calls=list(tool_calls),
+            )
+        )
+        turn_index += 1
+        text_parts = []
+        tool_calls = []
+
+    for item in result.new_items:
+        item_type = getattr(item, "type", "")
+        if item_type == "message_output_item":
+            # Flush any pending tool calls from previous turn
+            _flush()
+            raw = getattr(item, "raw_item", None)
+            if raw:
+                content = getattr(raw, "content", None) or []
+                for part in content:
+                    if hasattr(part, "text"):
+                        text_parts.append(part.text)
+        elif item_type == "tool_call_item":
+            raw = getattr(item, "raw_item", None)
+            if raw:
+                tc_name = getattr(raw, "name", "") or ""
+                tc_id = getattr(raw, "call_id", "") or getattr(raw, "id", "") or ""
+                tc_args = getattr(raw, "arguments", "{}") or "{}"
+                try:
+                    tc_input = json.loads(tc_args) if isinstance(tc_args, str) else tc_args
+                except (json.JSONDecodeError, TypeError):
+                    tc_input = {"raw": tc_args}
+                tool_calls.append(ToolCall(name=tc_name, input=tc_input, id=tc_id))
+        elif item_type == "tool_call_output_item":
+            output = getattr(item, "output", None)
+            # Attach output to the last matching tool call
+            if tool_calls:
+                tool_calls[-1].output = output
+
+    # Flush remaining
+    _flush()
+
+    # Distribute token usage from raw_responses across turns
+    raw_responses = getattr(result, "raw_responses", []) or []
+    for i, resp in enumerate(raw_responses):
+        usage = getattr(resp, "usage", None)
+        if usage and i < len(trajectory.turns):
+            trajectory.turns[i].input_tokens = getattr(usage, "input_tokens", 0) or 0
+            trajectory.turns[i].output_tokens = getattr(usage, "output_tokens", 0) or 0
+
+    return trajectory
+
+
+class OpenAIAgentRunner(AgentRunner):
+    """Agent runner that delegates to the OpenAI Agents SDK agentic loop.
+
+    The SDK handles tool discovery, invocation, and multi-turn conversation
+    against the registered MCP servers.
+
+    Args:
+        llm: Unused — OpenAIAgentRunner uses the OpenAI Agents SDK directly.
+             Accepted for interface compatibility with ``AgentRunner``.
+        server_paths: MCP server specs identical to ``PlanExecuteRunner``.
+                      Defaults to all registered servers.
+        model: OpenAI model ID to use (default: ``gpt-4o``).
+        max_turns: Maximum agentic loop turns (default: 30).
+    """
+
+    def __init__(
+        self,
+        llm=None,
+        server_paths: dict[str, Path | str] | None = None,
+        model: str = _DEFAULT_MODEL,
+        max_turns: int = 30,
+    ) -> None:
+        super().__init__(llm, server_paths)
+        self._model = model
+        self._max_turns = max_turns
+        self._resolved_server_paths: dict[str, Path | str] = (
+            server_paths if server_paths is not None else dict(DEFAULT_SERVER_PATHS)
+        )
+
+    async def run(self, question: str) -> AgentResult:
+        """Run the OpenAI Agents SDK loop for *question*.
+
+        Args:
+            question: Natural-language question to answer.
+
+        Returns:
+            AgentResult with the final answer and full execution trajectory.
+        """
+        mcp_servers = _build_mcp_servers(self._resolved_server_paths)
+
+        # Use async context managers to manage MCP server lifecycle
+        async with _managed_servers(mcp_servers) as active_servers:
+            agent = Agent(
+                name="AssetOps Assistant",
+                instructions=_SYSTEM_PROMPT,
+                mcp_servers=active_servers,
+                model=self._model,
+            )
+
+            _log.info(
+                "OpenAIAgentRunner: starting query (model=%s, servers=%d)",
+                self._model,
+                len(active_servers),
+            )
+
+            result = await Runner.run(
+                agent,
+                question,
+                max_turns=self._max_turns,
+            )
+
+            answer = result.final_output or ""
+            trajectory = _build_trajectory(result)
+
+            _log.info(
+                "OpenAIAgentRunner: done (turns=%d, input_tokens=%d, "
+                "output_tokens=%d)",
+                len(trajectory.turns),
+                trajectory.total_input_tokens,
+                trajectory.total_output_tokens,
+            )
+
+            return AgentResult(
+                question=question,
+                answer=answer,
+                trajectory=trajectory,
+            )
+
+
+class _managed_servers:
+    """Async context manager that enters all MCP server contexts."""
+
+    def __init__(self, servers: list[MCPServerStdio]) -> None:
+        self._servers = servers
+        self._entered: list[MCPServerStdio] = []
+
+    async def __aenter__(self) -> list[MCPServerStdio]:
+        for server in self._servers:
+            await server.__aenter__()
+            self._entered.append(server)
+        return self._entered
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        for server in reversed(self._entered):
+            try:
+                await server.__aexit__(exc_type, exc_val, exc_tb)
+            except Exception:
+                _log.warning("Failed to close MCP server %s", server.name, exc_info=True)

--- a/src/agent/openai_agent/tests/test_runner.py
+++ b/src/agent/openai_agent/tests/test_runner.py
@@ -88,15 +88,19 @@ def test_build_run_config_missing_env_raises(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_runner_defaults():
+def test_runner_defaults(monkeypatch):
+    monkeypatch.setenv("LITELLM_BASE_URL", "http://localhost:4000")
+    monkeypatch.setenv("LITELLM_API_KEY", "sk-test")
     runner = OpenAIAgentRunner()
-    assert runner._model == "gpt-4o"
-    assert runner._run_config is None
+    assert runner._model == "azure/gpt-5.4"
+    assert runner._run_config is not None
     assert runner._max_turns == 30
     assert "iot" in runner._resolved_server_paths
 
 
-def test_runner_custom_server_paths():
+def test_runner_custom_server_paths(monkeypatch):
+    monkeypatch.setenv("LITELLM_BASE_URL", "http://localhost:4000")
+    monkeypatch.setenv("LITELLM_API_KEY", "sk-test")
     paths = {"iot": "iot-mcp-server"}
     runner = OpenAIAgentRunner(server_paths=paths)
     assert runner._resolved_server_paths == paths
@@ -246,6 +250,7 @@ async def test_run_returns_agent_result():
     with (
         patch("agent.openai_agent.runner.Runner") as MockRunner,
         patch("agent.openai_agent.runner._build_mcp_servers", return_value=[]),
+        patch("agent.openai_agent.runner._build_run_config", return_value=None),
         patch("agent.openai_agent.runner._managed_servers") as MockCtx,
     ):
         MockRunner.run = AsyncMock(return_value=fake_result)
@@ -278,6 +283,7 @@ async def test_run_collects_trajectory():
     with (
         patch("agent.openai_agent.runner.Runner") as MockRunner,
         patch("agent.openai_agent.runner._build_mcp_servers", return_value=[]),
+        patch("agent.openai_agent.runner._build_run_config", return_value=None),
         patch("agent.openai_agent.runner._managed_servers") as MockCtx,
     ):
         MockRunner.run = AsyncMock(return_value=fake_result)
@@ -303,6 +309,7 @@ async def test_run_empty_result():
     with (
         patch("agent.openai_agent.runner.Runner") as MockRunner,
         patch("agent.openai_agent.runner._build_mcp_servers", return_value=[]),
+        patch("agent.openai_agent.runner._build_run_config", return_value=None),
         patch("agent.openai_agent.runner._managed_servers") as MockCtx,
     ):
         MockRunner.run = AsyncMock(return_value=fake_result)

--- a/src/agent/openai_agent/tests/test_runner.py
+++ b/src/agent/openai_agent/tests/test_runner.py
@@ -15,7 +15,9 @@ from agent.openai_agent.models import Trajectory
 from agent.openai_agent.runner import (
     OpenAIAgentRunner,
     _build_mcp_servers,
+    _build_run_config,
     _build_trajectory,
+    _resolve_model,
 )
 from agent.models import AgentResult
 
@@ -45,6 +47,43 @@ def test_build_mcp_servers_empty():
 
 
 # ---------------------------------------------------------------------------
+# _resolve_model
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_model_strips_litellm_prefix():
+    assert _resolve_model("litellm_proxy/Azure/gpt-5-2025-08-07") == "Azure/gpt-5-2025-08-07"
+
+
+def test_resolve_model_passthrough():
+    assert _resolve_model("gpt-4o") == "gpt-4o"
+
+
+# ---------------------------------------------------------------------------
+# _build_run_config
+# ---------------------------------------------------------------------------
+
+
+def test_build_run_config_no_prefix_returns_none():
+    assert _build_run_config("gpt-4o") is None
+
+
+def test_build_run_config_litellm_prefix(monkeypatch):
+    monkeypatch.setenv("LITELLM_BASE_URL", "http://localhost:4000")
+    monkeypatch.setenv("LITELLM_API_KEY", "sk-test")
+    config = _build_run_config("litellm_proxy/Azure/gpt-5-2025-08-07")
+    assert config is not None
+    assert config.model_provider is not None
+
+
+def test_build_run_config_missing_env_raises(monkeypatch):
+    monkeypatch.delenv("LITELLM_BASE_URL", raising=False)
+    monkeypatch.delenv("LITELLM_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="LITELLM_BASE_URL"):
+        _build_run_config("litellm_proxy/Azure/gpt-5-2025-08-07")
+
+
+# ---------------------------------------------------------------------------
 # OpenAIAgentRunner.__init__
 # ---------------------------------------------------------------------------
 
@@ -52,6 +91,7 @@ def test_build_mcp_servers_empty():
 def test_runner_defaults():
     runner = OpenAIAgentRunner()
     assert runner._model == "gpt-4o"
+    assert runner._run_config is None
     assert runner._max_turns == 30
     assert "iot" in runner._resolved_server_paths
 
@@ -65,6 +105,14 @@ def test_runner_custom_server_paths():
 def test_runner_custom_model():
     runner = OpenAIAgentRunner(model="gpt-4.1-mini")
     assert runner._model == "gpt-4.1-mini"
+
+
+def test_runner_litellm_model(monkeypatch):
+    monkeypatch.setenv("LITELLM_BASE_URL", "http://localhost:4000")
+    monkeypatch.setenv("LITELLM_API_KEY", "sk-test")
+    runner = OpenAIAgentRunner(model="litellm_proxy/Azure/gpt-5-2025-08-07")
+    assert runner._model == "Azure/gpt-5-2025-08-07"
+    assert runner._run_config is not None
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent/openai_agent/tests/test_runner.py
+++ b/src/agent/openai_agent/tests/test_runner.py
@@ -1,0 +1,269 @@
+"""Unit tests for OpenAIAgentRunner.
+
+These tests patch agents.Runner.run so no real API calls are made.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.openai_agent.models import Trajectory
+from agent.openai_agent.runner import (
+    OpenAIAgentRunner,
+    _build_mcp_servers,
+    _build_trajectory,
+)
+from agent.models import AgentResult
+
+
+# ---------------------------------------------------------------------------
+# _build_mcp_servers
+# ---------------------------------------------------------------------------
+
+
+def test_build_mcp_servers_entrypoint():
+    specs = {"iot": "iot-mcp-server", "utilities": "utilities-mcp-server"}
+    result = _build_mcp_servers(specs)
+    assert len(result) == 2
+    assert result[0].name == "iot"
+    assert result[1].name == "utilities"
+
+
+def test_build_mcp_servers_path():
+    p = Path("/some/server.py")
+    result = _build_mcp_servers({"custom": p})
+    assert len(result) == 1
+    assert result[0].name == "custom"
+
+
+def test_build_mcp_servers_empty():
+    assert _build_mcp_servers({}) == []
+
+
+# ---------------------------------------------------------------------------
+# OpenAIAgentRunner.__init__
+# ---------------------------------------------------------------------------
+
+
+def test_runner_defaults():
+    runner = OpenAIAgentRunner()
+    assert runner._model == "gpt-4o"
+    assert runner._max_turns == 30
+    assert "iot" in runner._resolved_server_paths
+
+
+def test_runner_custom_server_paths():
+    paths = {"iot": "iot-mcp-server"}
+    runner = OpenAIAgentRunner(server_paths=paths)
+    assert runner._resolved_server_paths == paths
+
+
+def test_runner_custom_model():
+    runner = OpenAIAgentRunner(model="gpt-4.1-mini")
+    assert runner._model == "gpt-4.1-mini"
+
+
+# ---------------------------------------------------------------------------
+# _build_trajectory
+# ---------------------------------------------------------------------------
+
+
+def _make_message_item(text: str):
+    """Create a fake MessageOutputItem."""
+    text_part = SimpleNamespace(text=text)
+    raw = SimpleNamespace(content=[text_part])
+    return SimpleNamespace(type="message_output_item", raw_item=raw)
+
+
+def _make_tool_call_item(name: str, args: str, call_id: str = "call_1"):
+    """Create a fake ToolCallItem."""
+    raw = SimpleNamespace(name=name, arguments=args, call_id=call_id)
+    return SimpleNamespace(type="tool_call_item", raw_item=raw)
+
+
+def _make_tool_output_item(output):
+    """Create a fake ToolCallOutputItem."""
+    return SimpleNamespace(type="tool_call_output_item", output=output)
+
+
+def _make_usage(input_tokens: int, output_tokens: int):
+    return SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens)
+
+
+def _make_run_result(items, raw_responses=None):
+    return SimpleNamespace(
+        new_items=items,
+        raw_responses=raw_responses or [],
+        final_output="test answer",
+    )
+
+
+def test_build_trajectory_empty():
+    result = _make_run_result([])
+    traj = _build_trajectory(result)
+    assert isinstance(traj, Trajectory)
+    assert traj.turns == []
+
+
+def test_build_trajectory_message_only():
+    result = _make_run_result([_make_message_item("Hello world")])
+    traj = _build_trajectory(result)
+    assert len(traj.turns) == 1
+    assert traj.turns[0].text == "Hello world"
+    assert traj.turns[0].tool_calls == []
+
+
+def test_build_trajectory_tool_calls():
+    items = [
+        _make_tool_call_item("sensors", '{"asset_id": "CH-6"}', "call_1"),
+        _make_tool_output_item("5 sensors found"),
+        _make_message_item("Chiller 6 has 5 sensors."),
+    ]
+    result = _make_run_result(items)
+    traj = _build_trajectory(result)
+    assert len(traj.turns) == 2
+    # First turn: tool call + output
+    assert len(traj.turns[0].tool_calls) == 1
+    tc = traj.turns[0].tool_calls[0]
+    assert tc.name == "sensors"
+    assert tc.input == {"asset_id": "CH-6"}
+    assert tc.id == "call_1"
+    assert tc.output == "5 sensors found"
+    # Second turn: message
+    assert traj.turns[1].text == "Chiller 6 has 5 sensors."
+
+
+def test_build_trajectory_token_usage():
+    items = [_make_message_item("Hello")]
+    raw_responses = [SimpleNamespace(usage=_make_usage(100, 25))]
+    result = _make_run_result(items, raw_responses)
+    traj = _build_trajectory(result)
+    assert traj.turns[0].input_tokens == 100
+    assert traj.turns[0].output_tokens == 25
+    assert traj.total_input_tokens == 100
+    assert traj.total_output_tokens == 25
+
+
+def test_build_trajectory_invalid_json_args():
+    items = [
+        _make_tool_call_item("sensors", "not-json", "call_1"),
+    ]
+    result = _make_run_result(items)
+    traj = _build_trajectory(result)
+    assert traj.turns[0].tool_calls[0].input == {"raw": "not-json"}
+
+
+def test_build_trajectory_multiple_tool_calls():
+    items = [
+        _make_tool_call_item("sites", "{}", "call_1"),
+        _make_tool_output_item(["MAIN"]),
+        _make_tool_call_item("assets", '{"site_id": "MAIN"}', "call_2"),
+        _make_tool_output_item(["Chiller 6"]),
+        _make_message_item("Found Chiller 6 at site MAIN."),
+    ]
+    # Two turns: (tool calls) and (message), so two raw_responses
+    raw = [
+        SimpleNamespace(usage=_make_usage(50, 10)),
+        SimpleNamespace(usage=_make_usage(80, 15)),
+    ]
+    result = _make_run_result(items, raw)
+    traj = _build_trajectory(result)
+    # Both tool calls land in the same turn (no message between them)
+    assert len(traj.turns) == 2
+    assert len(traj.all_tool_calls) == 2
+    assert traj.all_tool_calls[0].name == "sites"
+    assert traj.all_tool_calls[0].output == ["MAIN"]
+    assert traj.all_tool_calls[1].name == "assets"
+    assert traj.all_tool_calls[1].output == ["Chiller 6"]
+    assert traj.total_input_tokens == 50 + 80
+    assert traj.total_output_tokens == 10 + 15
+
+
+# ---------------------------------------------------------------------------
+# OpenAIAgentRunner.run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_run_returns_agent_result():
+    fake_result = _make_run_result(
+        [_make_message_item("42 sensors found")],
+    )
+    fake_result.final_output = "42 sensors found"
+
+    with (
+        patch("agent.openai_agent.runner.Runner") as MockRunner,
+        patch("agent.openai_agent.runner._build_mcp_servers", return_value=[]),
+        patch("agent.openai_agent.runner._managed_servers") as MockCtx,
+    ):
+        MockRunner.run = AsyncMock(return_value=fake_result)
+        MockCtx.return_value.__aenter__ = AsyncMock(return_value=[])
+        MockCtx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        runner = OpenAIAgentRunner(server_paths={})
+        result = await runner.run("How many sensors are there?")
+
+    assert isinstance(result, AgentResult)
+    assert result.question == "How many sensors are there?"
+    assert result.answer == "42 sensors found"
+    assert isinstance(result.trajectory, Trajectory)
+
+
+@pytest.mark.anyio
+async def test_run_collects_trajectory():
+    items = [
+        _make_tool_call_item("sensors", '{"asset_id": "CH-6"}', "call_1"),
+        _make_tool_output_item("sensor data"),
+        _make_message_item("Chiller 6 has 5 sensors."),
+    ]
+    raw_responses = [
+        SimpleNamespace(usage=_make_usage(100, 20)),
+        SimpleNamespace(usage=_make_usage(150, 30)),
+    ]
+    fake_result = _make_run_result(items, raw_responses)
+    fake_result.final_output = "Chiller 6 has 5 sensors."
+
+    with (
+        patch("agent.openai_agent.runner.Runner") as MockRunner,
+        patch("agent.openai_agent.runner._build_mcp_servers", return_value=[]),
+        patch("agent.openai_agent.runner._managed_servers") as MockCtx,
+    ):
+        MockRunner.run = AsyncMock(return_value=fake_result)
+        MockCtx.return_value.__aenter__ = AsyncMock(return_value=[])
+        MockCtx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        runner = OpenAIAgentRunner(server_paths={})
+        result = await runner.run("What sensors are on Chiller 6?")
+
+    traj = result.trajectory
+    assert len(traj.turns) == 2
+    assert len(traj.all_tool_calls) == 1
+    assert traj.all_tool_calls[0].name == "sensors"
+    assert traj.total_input_tokens == 100 + 150
+    assert traj.total_output_tokens == 20 + 30
+
+
+@pytest.mark.anyio
+async def test_run_empty_result():
+    fake_result = _make_run_result([])
+    fake_result.final_output = ""
+
+    with (
+        patch("agent.openai_agent.runner.Runner") as MockRunner,
+        patch("agent.openai_agent.runner._build_mcp_servers", return_value=[]),
+        patch("agent.openai_agent.runner._managed_servers") as MockCtx,
+    ):
+        MockRunner.run = AsyncMock(return_value=fake_result)
+        MockCtx.return_value.__aenter__ = AsyncMock(return_value=[])
+        MockCtx.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        runner = OpenAIAgentRunner(server_paths={})
+        result = await runner.run("What time is it?")
+
+    assert result.answer == ""
+    assert isinstance(result.trajectory, Trajectory)
+    assert result.trajectory.turns == []

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,7 @@ dependencies = [
     { name = "litellm" },
     { name = "mcp", extra = ["cli"] },
     { name = "numpy" },
+    { name = "openai-agents" },
     { name = "pandas" },
     { name = "pendulum" },
     { name = "pydantic" },
@@ -187,6 +188,7 @@ requires-dist = [
     { name = "litellm", specifier = "==1.81.13" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
     { name = "numpy", specifier = ">=1.24" },
+    { name = "openai-agents", specifier = ">=0.0.7" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pendulum", specifier = ">=3.2.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -841,6 +843,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -1687,7 +1698,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.21.0"
+version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1699,9 +1710,27 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/e5/3d197a0947a166649f566706d7a4c8f7fe38f1fa7b24c9bcffe4c7591d44/openai-2.21.0.tar.gz", hash = "sha256:81b48ce4b8bbb2cc3af02047ceb19561f7b1dc0d4e52d1de7f02abfd15aa59b7", size = 644374, upload-time = "2026-02-14T00:12:01.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/fe/64b3d035780b3188f86c4f6f1bc202e7bb74757ef028802112273b9dcacf/openai-2.31.0.tar.gz", hash = "sha256:43ca59a88fc973ad1848d86b98d7fac207e265ebbd1828b5e4bdfc85f79427a5", size = 684772, upload-time = "2026-04-08T21:01:41.797Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/56/0a89092a453bb2c676d66abee44f863e742b2110d4dbb1dbcca3f7e5fc33/openai-2.21.0-py3-none-any.whl", hash = "sha256:0bc1c775e5b1536c294eded39ee08f8407656537ccc71b1004104fe1602e267c", size = 1103065, upload-time = "2026-02-14T00:11:59.603Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bc/a8f7c3aa03452fedbb9af8be83e959adba96a6b4a35e416faffcc959c568/openai-2.31.0-py3-none-any.whl", hash = "sha256:44e1344d87e56a493d649b17e2fac519d1368cbb0745f59f1957c4c26de50a0a", size = 1153479, upload-time = "2026-04-08T21:01:39.217Z" },
+]
+
+[[package]]
+name = "openai-agents"
+version = "0.13.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffelib" },
+    { name = "mcp" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/e8/a3bc1a91af9c71d2934f8e2f3eee2954540fa95d47b0e3f155d348d91b38/openai_agents-0.13.6.tar.gz", hash = "sha256:de7b3add7933ae704a5ee6e531f650d8aabb3ebaa1631f458ba39684a5ed966e", size = 2704270, upload-time = "2026-04-09T04:10:51.581Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/83/a991b2ad389abadabf13f6c4228bd88ac8dc363e4b50fcae8c5ea966bd41/openai_agents-0.13.6-py3-none-any.whl", hash = "sha256:8decb9eb0cc5dbe7749858e97a7d8316f9439526ca4e539e3bd105e0eb41115e", size = 471763, upload-time = "2026-04-09T04:10:49.81Z" },
 ]
 
 [[package]]
@@ -2921,6 +2950,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds `OpenAIAgentRunner` under `src/agent/openai_agent/` using the [openai-agents](https://github.com/openai/openai-agents-python) SDK with MCP stdio server integration.

**Runner & CLI**
- Follows the same `AgentRunner` ABC pattern as `ClaudeAgentRunner` and `PlanExecuteRunner`
- CLI entry point (`openai-agent`) with trajectory capture, `--show-trajectory`, `--json`, and `--verbose` flags
- Defaults to `litellm_proxy/azure/gpt-5.4`; routes all requests through the LiteLLM proxy (requires `LITELLM_API_KEY` + `LITELLM_BASE_URL`; `OPENAI_API_KEY` no longer used)

**Ride-along changes**
- `claude-agent` default model flipped to `litellm_proxy/aws/claude-opus-4-6` for consistency with the new openai-agent default
- `INSTRUCTIONS.md` trimmed: each agent section now only contains "How it works" + "CLI"; added a shared `$query` examples block; removed the "Connect to Claude Desktop" section

Closes #257

## Test plan

- [x] `uv run pytest src/agent/openai_agent/tests/ -v` — all 15 tests pass
- [x] `uv run pytest src/agent/claude_agent/tests/ -v` — all 16 tests pass (default-model assertion updated)
- [x] `uv run pytest src/ -v -k "not integration"` — no regressions
- [x] `uv run openai-agent "$query"` — end-to-end via LiteLLM proxy
- [x] `uv run claude-agent "$query"` — end-to-end via LiteLLM proxy (new default)
