### PR TITLE
refactor: share system prompt and CLI boilerplate

### DIFF
--- a/src/agent/_cli_common.py
+++ b/src/agent/_cli_common.py
@@ -1,0 +1,109 @@
+"""Shared CLI helpers for the SDK-driven agent entry points.
+
+The three SDK CLIs (``claude-agent``, ``openai-agent``, ``deep-agent``) all
+need to parse a question + model ID, set up logging, and print a
+trajectory + answer section.  This module captures that common surface so
+each CLI only has to encode its runner-specific differences
+(prog name, default model, loop-bound arg like ``--max-turns`` vs
+``--recursion-limit``, and which runner class to instantiate).
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import sys
+
+LOG_FORMAT = "%(asctime)s  %(levelname)-8s  %(name)s  %(message)s"
+LOG_DATE_FORMAT = "%H:%M:%S"
+HR = "─" * 60
+
+
+def setup_logging(verbose: bool) -> None:
+    """Configure the root logger to stderr; INFO when verbose else WARNING."""
+    level = logging.INFO if verbose else logging.WARNING
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter(LOG_FORMAT, datefmt=LOG_DATE_FORMAT))
+    logging.root.handlers.clear()
+    logging.root.addHandler(handler)
+    logging.root.setLevel(level)
+
+
+def add_common_args(parser: argparse.ArgumentParser, default_model: str) -> None:
+    """Register the args shared by every SDK CLI.
+
+    Adds the positional ``question`` plus ``--model-id``, ``--show-trajectory``,
+    ``--json``, and ``--verbose``.  The caller is responsible for any
+    runner-specific flags (e.g. ``--max-turns``, ``--recursion-limit``).
+    """
+    parser.add_argument("question", help="The question to answer.")
+    parser.add_argument(
+        "--model-id",
+        default=default_model,
+        metavar="MODEL_ID",
+        help=f"Model string (default: {default_model}).",
+    )
+    parser.add_argument(
+        "--show-trajectory",
+        action="store_true",
+        help="Print each turn's text, tool calls, and token usage.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="output_json",
+        help="Output the full result as JSON.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show INFO-level logs on stderr.",
+    )
+
+
+def print_trajectory(trajectory) -> None:
+    """Pretty-print turns, tool calls, and token totals to stdout."""
+    print(f"\n{HR}")
+    print("  Trace")
+    print(HR)
+    for turn in trajectory.turns:
+        print(
+            f"\n  [Turn {turn.index}]  "
+            f"in={turn.input_tokens} out={turn.output_tokens} tokens"
+        )
+        if turn.text:
+            snippet = turn.text[:200] + ("..." if len(turn.text) > 200 else "")
+            print(f"    text: {snippet}")
+        for tc in turn.tool_calls:
+            print(f"    tool: {tc.name}  input: {tc.input}")
+            if tc.output is not None:
+                out_str = str(tc.output)
+                snippet = out_str[:200] + ("..." if len(out_str) > 200 else "")
+                print(f"    output: {snippet}")
+    print(
+        f"\n  Total: {trajectory.total_input_tokens} input / "
+        f"{trajectory.total_output_tokens} output tokens  "
+        f"({len(trajectory.turns)} turns, "
+        f"{len(trajectory.all_tool_calls)} tool calls)"
+    )
+
+
+def print_answer(answer: str) -> None:
+    """Print the final answer section."""
+    print(f"\n{HR}")
+    print("  Answer")
+    print(HR)
+    print(answer)
+    print()
+
+
+def print_result(result, *, show_trajectory: bool, output_json: bool) -> None:
+    """Common post-run output: JSON dump OR trajectory + answer sections."""
+    if output_json:
+        print(json.dumps(dataclasses.asdict(result.trajectory), indent=2, default=str))
+        return
+    if show_trajectory:
+        print_trajectory(result.trajectory)
+    print_answer(result.answer)

--- a/src/agent/_prompts.py
+++ b/src/agent/_prompts.py
@@ -1,0 +1,16 @@
+"""Shared prompts used by the SDK-driven agent runners.
+
+The plan-execute runner uses its own planning/summarisation prompts in
+:mod:`agent.plan_execute` and does not share these.
+"""
+
+from __future__ import annotations
+
+AGENT_SYSTEM_PROMPT = """\
+You are an industrial asset operations assistant with access to MCP tools for
+querying IoT sensor data, failure mode and symptom records, time-series
+forecasting models, and work order management.
+
+Answer the user's question concisely and accurately using the available tools.
+When you retrieve data, include the key numbers or names in your answer.
+"""

--- a/src/agent/claude_agent/cli.py
+++ b/src/agent/claude_agent/cli.py
@@ -11,15 +11,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import dataclasses
-import json
-import logging
-import sys
+
+from .._cli_common import add_common_args, print_result, setup_logging
 
 _DEFAULT_MODEL = "litellm_proxy/aws/claude-opus-4-6"
-_LOG_FORMAT = "%(asctime)s  %(levelname)-8s  %(name)s  %(message)s"
-_LOG_DATE_FORMAT = "%H:%M:%S"
-_HR = "─" * 60
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -27,7 +22,7 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="claude-agent",
         description="Run a question through the Claude Agent SDK with AssetOpsBench MCP servers.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=f"""
+        epilog="""
 environment variables:
   LITELLM_API_KEY       LiteLLM / Anthropic API key (required)
   LITELLM_BASE_URL      LiteLLM proxy URL (required for litellm_proxy/* models)
@@ -36,17 +31,11 @@ examples:
   claude-agent "What assets are at site MAIN?"
   claude-agent --model-id claude-opus-4-6 --max-turns 20 "List sensors on Chiller 6"
   claude-agent --model-id litellm_proxy/aws/claude-opus-4-6 "What is the current time?"
-  claude-agent --show-history "What sensors are on Chiller 6?"
+  claude-agent --show-trajectory "What sensors are on Chiller 6?"
   claude-agent --json "What is the current time?"
 """,
     )
-    parser.add_argument("question", help="The question to answer.")
-    parser.add_argument(
-        "--model-id",
-        default=_DEFAULT_MODEL,
-        metavar="MODEL_ID",
-        help=f"Claude model ID (default: {_DEFAULT_MODEL}).",
-    )
+    add_common_args(parser, default_model=_DEFAULT_MODEL)
     parser.add_argument(
         "--max-turns",
         type=int,
@@ -54,54 +43,7 @@ examples:
         metavar="N",
         help="Maximum agentic loop turns (default: 30).",
     )
-    parser.add_argument(
-        "--show-trajectory",
-        action="store_true",
-        help="Print each turn's text, tool calls, and token usage.",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        dest="output_json",
-        help="Output the full result as JSON.",
-    )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Show INFO-level logs on stderr.",
-    )
     return parser
-
-
-def _setup_logging(verbose: bool) -> None:
-    level = logging.INFO if verbose else logging.WARNING
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATE_FORMAT))
-    logging.root.handlers.clear()
-    logging.root.addHandler(handler)
-    logging.root.setLevel(level)
-
-
-def _print_trace(trajectory) -> None:
-    print(f"\n{_HR}")
-    print("  Trace")
-    print(_HR)
-    for turn in trajectory.turns:
-        print(f"\n  [Turn {turn.index}]  "
-              f"in={turn.input_tokens} out={turn.output_tokens} tokens")
-        if turn.text:
-            snippet = turn.text[:200] + ("..." if len(turn.text) > 200 else "")
-            print(f"    text: {snippet}")
-        for tc in turn.tool_calls:
-            print(f"    tool: {tc.name}  input: {tc.input}")
-            if tc.output is not None:
-                out_str = str(tc.output)
-                snippet = out_str[:200] + ("..." if len(out_str) > 200 else "")
-                print(f"    output: {snippet}")
-    print(f"\n  Total: {trajectory.total_input_tokens} input / "
-          f"{trajectory.total_output_tokens} output tokens  "
-          f"({len(trajectory.turns)} turns, "
-          f"{len(trajectory.all_tool_calls)} tool calls)")
 
 
 async def _run(args: argparse.Namespace) -> None:
@@ -109,19 +51,7 @@ async def _run(args: argparse.Namespace) -> None:
 
     runner = ClaudeAgentRunner(model=args.model_id, max_turns=args.max_turns)
     result = await runner.run(args.question)
-
-    if args.output_json:
-        print(json.dumps(dataclasses.asdict(result.trajectory), indent=2))
-        return
-
-    if args.show_trajectory:
-        _print_trace(result.trajectory)
-
-    print(f"\n{_HR}")
-    print("  Answer")
-    print(_HR)
-    print(result.answer)
-    print()
+    print_result(result, show_trajectory=args.show_trajectory, output_json=args.output_json)
 
 
 def main() -> None:
@@ -131,7 +61,7 @@ def main() -> None:
 
     load_dotenv()
     args = _build_parser().parse_args()
-    _setup_logging(args.verbose)
+    setup_logging(args.verbose)
     init_tracing("claude-agent")
     asyncio.run(_run(args))
 

--- a/src/agent/claude_agent/runner.py
+++ b/src/agent/claude_agent/runner.py
@@ -25,6 +25,7 @@ from claude_agent_sdk import TextBlock, ToolUseBlock
 from observability import agent_run_span, annotate_result
 
 from .._litellm import LITELLM_PREFIX, resolve_model
+from .._prompts import AGENT_SYSTEM_PROMPT
 from ..models import AgentResult, ToolCall, Trajectory, TurnRecord
 from ..plan_execute.executor import DEFAULT_SERVER_PATHS
 from ..runner import AgentRunner
@@ -49,15 +50,6 @@ def _sdk_env(model_id: str) -> dict[str, str] | None:
     if api_key := os.environ.get("LITELLM_API_KEY"):
         env["ANTHROPIC_API_KEY"] = api_key
     return env or None
-
-_SYSTEM_PROMPT = """\
-You are an industrial asset operations assistant with access to MCP tools for
-querying IoT sensor data, failure mode and symptom records, time-series
-forecasting models, and work order management.
-
-Answer the user's question concisely and accurately using the available tools.
-When you retrieve data, include the key numbers or names in your answer.
-"""
 
 
 def _build_mcp_servers(
@@ -128,7 +120,7 @@ class ClaudeAgentRunner(AgentRunner):
 
             options = ClaudeAgentOptions(
                 model=self._model,
-                system_prompt=_SYSTEM_PROMPT,
+                system_prompt=AGENT_SYSTEM_PROMPT,
                 mcp_servers=mcp_servers,
                 max_turns=self._max_turns,
                 permission_mode=self._permission_mode,

--- a/src/agent/deep_agent/cli.py
+++ b/src/agent/deep_agent/cli.py
@@ -11,15 +11,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import dataclasses
-import json
-import logging
-import sys
+
+from .._cli_common import add_common_args, print_result, setup_logging
 
 _DEFAULT_MODEL = "litellm_proxy/aws/claude-opus-4-6"
-_LOG_FORMAT = "%(asctime)s  %(levelname)-8s  %(name)s  %(message)s"
-_LOG_DATE_FORMAT = "%H:%M:%S"
-_HR = "─" * 60
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -27,7 +22,7 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="deep-agent",
         description="Run a question through LangChain deep-agents with AssetOpsBench MCP servers.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=f"""
+        epilog="""
 model-id format:
   litellm_proxy/<model>   LiteLLM proxy (e.g. litellm_proxy/aws/claude-opus-4-6)
   <provider>:<model>      Native provider (e.g. anthropic:claude-sonnet-4-6)
@@ -43,13 +38,7 @@ examples:
   deep-agent --json "What is the current time?"
 """,
     )
-    parser.add_argument("question", help="The question to answer.")
-    parser.add_argument(
-        "--model-id",
-        default=_DEFAULT_MODEL,
-        metavar="MODEL_ID",
-        help=f"Model string; LiteLLM proxy or native provider (default: {_DEFAULT_MODEL}).",
-    )
+    add_common_args(parser, default_model=_DEFAULT_MODEL)
     parser.add_argument(
         "--recursion-limit",
         type=int,
@@ -57,54 +46,7 @@ examples:
         metavar="N",
         help="Maximum graph recursion steps (default: 100).",
     )
-    parser.add_argument(
-        "--show-trajectory",
-        action="store_true",
-        help="Print each turn's text, tool calls, and token usage.",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        dest="output_json",
-        help="Output the full result as JSON.",
-    )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Show INFO-level logs on stderr.",
-    )
     return parser
-
-
-def _setup_logging(verbose: bool) -> None:
-    level = logging.INFO if verbose else logging.WARNING
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATE_FORMAT))
-    logging.root.handlers.clear()
-    logging.root.addHandler(handler)
-    logging.root.setLevel(level)
-
-
-def _print_trace(trajectory) -> None:
-    print(f"\n{_HR}")
-    print("  Trace")
-    print(_HR)
-    for turn in trajectory.turns:
-        print(f"\n  [Turn {turn.index}]  "
-              f"in={turn.input_tokens} out={turn.output_tokens} tokens")
-        if turn.text:
-            snippet = turn.text[:200] + ("..." if len(turn.text) > 200 else "")
-            print(f"    text: {snippet}")
-        for tc in turn.tool_calls:
-            print(f"    tool: {tc.name}  input: {tc.input}")
-            if tc.output is not None:
-                out_str = str(tc.output)
-                snippet = out_str[:200] + ("..." if len(out_str) > 200 else "")
-                print(f"    output: {snippet}")
-    print(f"\n  Total: {trajectory.total_input_tokens} input / "
-          f"{trajectory.total_output_tokens} output tokens  "
-          f"({len(trajectory.turns)} turns, "
-          f"{len(trajectory.all_tool_calls)} tool calls)")
 
 
 async def _run(args: argparse.Namespace) -> None:
@@ -115,19 +57,7 @@ async def _run(args: argparse.Namespace) -> None:
         recursion_limit=args.recursion_limit,
     )
     result = await runner.run(args.question)
-
-    if args.output_json:
-        print(json.dumps(dataclasses.asdict(result.trajectory), indent=2, default=str))
-        return
-
-    if args.show_trajectory:
-        _print_trace(result.trajectory)
-
-    print(f"\n{_HR}")
-    print("  Answer")
-    print(_HR)
-    print(result.answer)
-    print()
+    print_result(result, show_trajectory=args.show_trajectory, output_json=args.output_json)
 
 
 def main() -> None:
@@ -137,7 +67,7 @@ def main() -> None:
 
     load_dotenv()
     args = _build_parser().parse_args()
-    _setup_logging(args.verbose)
+    setup_logging(args.verbose)
     init_tracing("deep-agent")
     asyncio.run(_run(args))
 

--- a/src/agent/deep_agent/runner.py
+++ b/src/agent/deep_agent/runner.py
@@ -25,6 +25,7 @@ from langchain_core.messages import AIMessage, ToolMessage
 from observability import agent_run_span, annotate_result
 
 from .._litellm import LITELLM_PREFIX, resolve_model
+from .._prompts import AGENT_SYSTEM_PROMPT
 from ..models import AgentResult, ToolCall, Trajectory, TurnRecord
 from ..plan_execute.executor import DEFAULT_SERVER_PATHS
 from ..runner import AgentRunner
@@ -63,16 +64,6 @@ def _build_chat_model(model_id: str):
     from langchain.chat_models import init_chat_model
 
     return init_chat_model(model_id)
-
-
-_SYSTEM_PROMPT = """\
-You are an industrial asset operations assistant with access to MCP tools for
-querying IoT sensor data, failure mode and symptom records, time-series
-forecasting models, and work order management.
-
-Answer the user's question concisely and accurately using the available tools.
-When you retrieve data, include the key numbers or names in your answer.
-"""
 
 
 def _build_mcp_connections(
@@ -206,7 +197,7 @@ class DeepAgentRunner(AgentRunner):
             agent = create_deep_agent(
                 model=chat_model,
                 tools=tools,
-                system_prompt=_SYSTEM_PROMPT,
+                system_prompt=AGENT_SYSTEM_PROMPT,
             )
 
             _log.info(

--- a/src/agent/openai_agent/cli.py
+++ b/src/agent/openai_agent/cli.py
@@ -11,15 +11,10 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import dataclasses
-import json
-import logging
-import sys
+
+from .._cli_common import add_common_args, print_result, setup_logging
 
 _DEFAULT_MODEL = "litellm_proxy/azure/gpt-5.4"
-_LOG_FORMAT = "%(asctime)s  %(levelname)-8s  %(name)s  %(message)s"
-_LOG_DATE_FORMAT = "%H:%M:%S"
-_HR = "─" * 60
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -27,7 +22,7 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="openai-agent",
         description="Run a question through the OpenAI Agents SDK with AssetOpsBench MCP servers.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=f"""
+        epilog="""
 model-id format:
   litellm_proxy/<model>   LiteLLM proxy (e.g. litellm_proxy/azure/gpt-5.4)
 
@@ -42,13 +37,7 @@ examples:
   openai-agent --json "What is the current time?"
 """,
     )
-    parser.add_argument("question", help="The question to answer.")
-    parser.add_argument(
-        "--model-id",
-        default=_DEFAULT_MODEL,
-        metavar="MODEL_ID",
-        help=f"LiteLLM model string with litellm_proxy/ prefix (default: {_DEFAULT_MODEL}).",
-    )
+    add_common_args(parser, default_model=_DEFAULT_MODEL)
     parser.add_argument(
         "--max-turns",
         type=int,
@@ -56,54 +45,7 @@ examples:
         metavar="N",
         help="Maximum agentic loop turns (default: 30).",
     )
-    parser.add_argument(
-        "--show-trajectory",
-        action="store_true",
-        help="Print each turn's text, tool calls, and token usage.",
-    )
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        dest="output_json",
-        help="Output the full result as JSON.",
-    )
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Show INFO-level logs on stderr.",
-    )
     return parser
-
-
-def _setup_logging(verbose: bool) -> None:
-    level = logging.INFO if verbose else logging.WARNING
-    handler = logging.StreamHandler(sys.stderr)
-    handler.setFormatter(logging.Formatter(_LOG_FORMAT, datefmt=_LOG_DATE_FORMAT))
-    logging.root.handlers.clear()
-    logging.root.addHandler(handler)
-    logging.root.setLevel(level)
-
-
-def _print_trace(trajectory) -> None:
-    print(f"\n{_HR}")
-    print("  Trace")
-    print(_HR)
-    for turn in trajectory.turns:
-        print(f"\n  [Turn {turn.index}]  "
-              f"in={turn.input_tokens} out={turn.output_tokens} tokens")
-        if turn.text:
-            snippet = turn.text[:200] + ("..." if len(turn.text) > 200 else "")
-            print(f"    text: {snippet}")
-        for tc in turn.tool_calls:
-            print(f"    tool: {tc.name}  input: {tc.input}")
-            if tc.output is not None:
-                out_str = str(tc.output)
-                snippet = out_str[:200] + ("..." if len(out_str) > 200 else "")
-                print(f"    output: {snippet}")
-    print(f"\n  Total: {trajectory.total_input_tokens} input / "
-          f"{trajectory.total_output_tokens} output tokens  "
-          f"({len(trajectory.turns)} turns, "
-          f"{len(trajectory.all_tool_calls)} tool calls)")
 
 
 async def _run(args: argparse.Namespace) -> None:
@@ -111,19 +53,7 @@ async def _run(args: argparse.Namespace) -> None:
 
     runner = OpenAIAgentRunner(model=args.model_id, max_turns=args.max_turns)
     result = await runner.run(args.question)
-
-    if args.output_json:
-        print(json.dumps(dataclasses.asdict(result.trajectory), indent=2))
-        return
-
-    if args.show_trajectory:
-        _print_trace(result.trajectory)
-
-    print(f"\n{_HR}")
-    print("  Answer")
-    print(_HR)
-    print(result.answer)
-    print()
+    print_result(result, show_trajectory=args.show_trajectory, output_json=args.output_json)
 
 
 def main() -> None:
@@ -133,7 +63,7 @@ def main() -> None:
 
     load_dotenv()
     args = _build_parser().parse_args()
-    _setup_logging(args.verbose)
+    setup_logging(args.verbose)
     init_tracing("openai-agent")
     asyncio.run(_run(args))
 

--- a/src/agent/openai_agent/runner.py
+++ b/src/agent/openai_agent/runner.py
@@ -28,6 +28,7 @@ from agents.mcp import MCPServerStdio
 from observability import agent_run_span, annotate_result
 
 from .._litellm import LITELLM_PREFIX, resolve_model
+from .._prompts import AGENT_SYSTEM_PROMPT
 from ..models import AgentResult, ToolCall, Trajectory, TurnRecord
 from ..plan_execute.executor import DEFAULT_SERVER_PATHS
 from ..runner import AgentRunner
@@ -70,16 +71,6 @@ def _build_run_config(model_id: str) -> RunConfig | None:
             )
 
     return RunConfig(model_provider=_LiteLLMModelProvider())
-
-
-_SYSTEM_PROMPT = """\
-You are an industrial asset operations assistant with access to MCP tools for
-querying IoT sensor data, failure mode and symptom records, time-series
-forecasting models, and work order management.
-
-Answer the user's question concisely and accurately using the available tools.
-When you retrieve data, include the key numbers or names in your answer.
-"""
 
 
 def _build_mcp_servers(
@@ -228,7 +219,7 @@ class OpenAIAgentRunner(AgentRunner):
             async with _managed_servers(mcp_servers) as active_servers:
                 agent = Agent(
                     name="AssetOps Assistant",
-                    instructions=_SYSTEM_PROMPT,
+                    instructions=AGENT_SYSTEM_PROMPT,
                     mcp_servers=active_servers,
                     model=self._model,
                 )

--- a/src/llm/litellm.py
+++ b/src/llm/litellm.py
@@ -18,6 +18,8 @@ import os
 
 from .base import LLMBackend
 
+_WATSONX_PREFIX = "watsonx/"
+
 
 class LiteLLMBackend(LLMBackend):
     """LLM backend using the litellm library.
@@ -41,7 +43,7 @@ class LiteLLMBackend(LLMBackend):
             "max_tokens": 2048,
         }
 
-        if self._model_id.startswith("watsonx/"):
+        if self._model_id.startswith(_WATSONX_PREFIX):
             kwargs["api_key"] = os.environ["WATSONX_APIKEY"]
             kwargs["project_id"] = os.environ["WATSONX_PROJECT_ID"]
             if url := os.environ.get("WATSONX_URL"):


### PR DESCRIPTION
Third in the stack, based on #273.

## Summary

- **`src/agent/_prompts.py`**: single `AGENT_SYSTEM_PROMPT` used by the three SDK runners. Three identical 7-line docstrings collapsed to one import. `plan_execute` keeps its own planning / summarisation prompts (different shape).
- **`src/agent/_cli_common.py`**: `setup_logging`, `add_common_args`, `print_trajectory`, `print_answer`, `print_result`. The three SDK CLIs now only encode their prog name, default model, epilog text, and runner-specific arg (`--max-turns` vs `--recursion-limit`) — each CLI shrunk from ~140 LoC to ~60 LoC.
- **`src/llm/litellm.py`**: extracted `_WATSONX_PREFIX` as a module-level constant to replace the magic string (tiny cosmetic win).

Net **-110 lines** across the CLIs and runners. Behavior is identical; I verified all three CLIs still print the expected `--help` output.

## Test plan

- [x] `uv run pytest src/ -k "not integration"` — 251 pass, 3 skipped. Same pre-existing CouchDB failure as before.
- [x] `uv run claude-agent --help`, `uv run openai-agent --help`, `uv run deep-agent --help` all render correctly.

## Not included

- **`src/tmp/` cleanup** — the 33 MB `workorder_agent/data_internal/` CSV payload is unreferenced by any Python, but may be source data someone depends on. Deferred pending explicit A/B/C decision from reviewer (delete all / small dirs only / leave everything).