### PR TITLE
fix(packaging): include src/servers in wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/agent", "src/llm", "src/observability"]
+packages = ["src/agent", "src/llm", "src/observability", "src/servers"]
 
 [project]
 name = "assetopsbench-mcp"


### PR DESCRIPTION
## Summary
- Add `src/servers` to `[tool.hatch.build.targets.wheel].packages` so the `servers` top-level package is shipped in the wheel.
- Fixes `ModuleNotFoundError: No module named 'servers'` for all `*-mcp-server` console scripts after a non-editable install.

## Why
Entrypoints in `pyproject.toml` reference `servers.iot.main:main`, `servers.tsfm.main:main`, etc., but the wheel build config only packaged `src/agent`, `src/llm`, and `src/observability`. Local `uv run` worked because the project was resolved via the source layout, masking the bug.

Verified by building the wheel and inspecting its contents — `servers/iot/main.py`, `servers/tsfm/main.py`, etc. are now included.

Closes #277

## Test plan
- [x] `uv run pytest src/ -v -k "not integration"` — 270 passed
- [x] `uv build --wheel` — wheel now contains `servers/**/main.py`
- [ ] Reviewer: smoke-test `pip install dist/assetopsbench_mcp-0.1.0-py3-none-any.whl` in a clean venv and run `iot-mcp-server --help` (or any other `*-mcp-server`) to confirm the entrypoint resolves