### PR TITLE
fix(agent): widen MCP client-session timeout for cold first runs

### DIFF
--- a/src/agent/deep_agent/runner.py
+++ b/src/agent/deep_agent/runner.py
@@ -38,6 +38,11 @@ _REPO_ROOT = Path(__file__).parent.parent.parent.parent
 
 _DEFAULT_MODEL = "litellm_proxy/aws/claude-opus-4-6"
 
+# MCP client-session timeout for stdio servers.  Cold-cache first spawns of
+# heavy servers (vibration imports scipy + numpy + DSP) can exceed the mcp
+# library's default handshake budget.  Warm runs are sub-second.
+_MCP_CLIENT_TIMEOUT_SECONDS = 30
+
 
 def _build_chat_model(model_id: str):
     """Construct a LangChain chat model for *model_id*.
@@ -85,6 +90,11 @@ def _build_mcp_connections(
             "command": "uv",
             "args": ["run", cmd_arg],
             "cwd": str(_REPO_ROOT),
+            "session_kwargs": {
+                "read_timeout_seconds": _dt.timedelta(
+                    seconds=_MCP_CLIENT_TIMEOUT_SECONDS
+                ),
+            },
         }
     return connections
 

--- a/src/agent/openai_agent/runner.py
+++ b/src/agent/openai_agent/runner.py
@@ -39,6 +39,12 @@ _log = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "litellm_proxy/azure/gpt-5.4"
 
+# MCP client-session timeout for stdio servers.  The SDK default of 5s is too
+# tight for first-spawn cold-cache cases (heavy imports like scipy/numpy push
+# vibration cold start past 10s on a freshly synced env).  Warm handshakes are
+# all sub-second so a generous value has no operational downside.
+_MCP_CLIENT_TIMEOUT_SECONDS = 30
+
 
 def _build_run_config(model_id: str) -> RunConfig | None:
     """Build a RunConfig with a LiteLLM model provider when needed.
@@ -95,6 +101,7 @@ def _build_mcp_servers(
                     "args": ["run", cmd_arg],
                 },
                 cache_tools_list=True,
+                client_session_timeout_seconds=_MCP_CLIENT_TIMEOUT_SECONDS,
             )
         )
     return servers


### PR DESCRIPTION
Closes #335.

## Summary

- `openai-agent` runner now passes `client_session_timeout_seconds=30` to `MCPServerStdio(...)` (was the SDK default of 5s).
- `deep-agent` runner now passes `session_kwargs={"read_timeout_seconds": timedelta(seconds=30)}` per connection.
- Each runner defines a module-level `_MCP_CLIENT_TIMEOUT_SECONDS = 30` constant alongside `_DEFAULT_MODEL`.
- `claude-agent` is intentionally untouched — its Python-side initialize timeout already defaults to 60s, and the stdio MCP servers it spawns are managed by the bundled Claude Code CLI subprocess (no Python-side knob).

## Why 30s

Cold-cache first-spawn timings measured on a freshly synced env: vibration server ~12s (one-time, scipy + numpy + DSP submodule imports). Warm handshakes across all six servers: 0.26s–0.89s. 30s leaves substantial margin without making a genuinely misconfigured server feel slow to fail.

## Test plan

- [x] `uv run pytest src/agent/ -k "not integration"` — 132/132 pass.
- [x] Manual smoke: `uv run openai-agent --model-id gpt-4.1 "What is the current date and time?"` — all 6 servers spawn cleanly, agent returns the expected answer.
- [ ] Maintainer to confirm the timeout choice / constant location matches repo conventions.