### PR TITLE
feat: add workorder and failure-code datasets for FCC task

### DIFF
--- a/src/couchdb/scenarios_data/shared/failure_code/failure_code.csv
+++ b/src/couchdb/scenarios_data/shared/failure_code/failure_code.csv
@@ -1,0 +1,23 @@
+code,description
+FC001,Breakdown
+FC002,Plugged / choked
+FC003,Leaking
+FC004,Minor in-service problems
+FC005,Structural deficiency
+FC006,Noise
+FC007,Failure to start on demand
+FC008,Vibration
+FC009,Overheating
+FC010,Fail to function
+FC011,Low output
+FC012,Electrical
+FC013,Failure to stop on demand
+FC014,Abnormal instrument reading
+FC015,Other
+FC016,Fail to close
+FC017,Contamination
+FC018,High output
+FC019,Erratic output
+FC020,Failure to rotate
+FC021,Spurious stop
+FC022,Fail to open

--- a/src/couchdb/scenarios_data/shared/failure_code/failure_code_sample.csv
+++ b/src/couchdb/scenarios_data/shared/failure_code/failure_code_sample.csv
@@ -1,11 +1,23 @@
 code,description
-FC001,equipment does not start
-FC002,equipment stops unexpectedly during operation
-FC003,abnormal noise during operation
-FC004,fluid leak observed
-FC005,"excessive vibration, shaking, or instability"
-FC006,overheating or high temperature reading
-FC007,indicator light does not illuminate
-FC008,gauge does not operate or is inaccurate
-FC009,structural damage or cracking
-FC010,part missing or loose
+FC001,Breakdown
+FC002,Plugged / choked
+FC003,Leaking
+FC004,Minor in-service problems
+FC005,Structural deficiency
+FC006,Noise
+FC007,Failure to start on demand
+FC008,Vibration
+FC009,Overheating
+FC010,Fail to function
+FC011,Low output
+FC012,Electrical
+FC013,Failure to stop on demand
+FC014,Abnormal instrument reading
+FC015,Other
+FC016,Fail to close
+FC017,Contamination
+FC018,High output
+FC019,Erratic output
+FC020,Failure to rotate
+FC021,Spurious stop
+FC022,Fail to open

--- a/src/couchdb/scenarios_data/shared/failure_code/failure_code_sample.csv
+++ b/src/couchdb/scenarios_data/shared/failure_code/failure_code_sample.csv
@@ -1,23 +1,11 @@
 code,description
-FC001,Breakdown
-FC002,Plugged / choked
-FC003,Leaking
-FC004,Minor in-service problems
-FC005,Structural deficiency
-FC006,Noise
-FC007,Failure to start on demand
-FC008,Vibration
-FC009,Overheating
-FC010,Fail to function
-FC011,Low output
-FC012,Electrical
-FC013,Failure to stop on demand
-FC014,Abnormal instrument reading
-FC015,Other
-FC016,Fail to close
-FC017,Contamination
-FC018,High output
-FC019,Erratic output
-FC020,Failure to rotate
-FC021,Spurious stop
-FC022,Fail to open
+FC001,equipment does not start
+FC002,equipment stops unexpectedly during operation
+FC003,abnormal noise during operation
+FC004,fluid leak observed
+FC005,"excessive vibration, shaking, or instability"
+FC006,overheating or high temperature reading
+FC007,indicator light does not illuminate
+FC008,gauge does not operate or is inaccurate
+FC009,structural damage or cracking
+FC010,part missing or loose

--- a/src/couchdb/scenarios_data/shared/work_order/fmc_train_wo.csv
+++ b/src/couchdb/scenarios_data/shared/work_order/fmc_train_wo.csv
@@ -1,0 +1,503 @@
+wo_id,description,failure_code
+TRN-WO00001,falure,Breakdown
+TRN-WO00002,unserviceable dpr 1,Breakdown
+TRN-WO00003,bogged,Plugged / choked
+TRN-WO00004,spaying slurry,Leaking
+TRN-WO00005,fell of,Minor in-service problems
+TRN-WO00006,no pressure output,Plugged / choked
+TRN-WO00007,damageblockage,Structural deficiency
+TRN-WO00008,squeeling,Noise
+TRN-WO00009,requires repacking,Minor in-service problems
+TRN-WO00010,no starting issue,Failure to start on demand
+TRN-WO00011,shaking,Vibration
+TRN-WO00012,blow,Minor in-service problems
+TRN-WO00013,need a descale,Minor in-service problems
+TRN-WO00014,over heating,Overheating
+TRN-WO00015,vibrationcheck,Vibration
+TRN-WO00016,vibration issue,Vibration
+TRN-WO00017,not open,Minor in-service problems
+TRN-WO00018,sticking,Fail to function
+TRN-WO00019,seized shut,Breakdown
+TRN-WO00020,blocked,Plugged / choked
+TRN-WO00021,not working,Breakdown
+TRN-WO00022,not energising,Low output
+TRN-WO00023,power issue,Electrical
+TRN-WO00024,needs repairing,Structural deficiency
+TRN-WO00025,not performing,Breakdown
+TRN-WO00026,wont run and,Failure to start on demand
+TRN-WO00027,boil out,Overheating
+TRN-WO00028,not supplying,Plugged / choked
+TRN-WO00029,spilled,Leaking
+TRN-WO00030,stuck in,Fail to function
+TRN-WO00031,leak exponentially,Leaking
+TRN-WO00032,not keeping up,Low output
+TRN-WO00033,pumping issue,Low output
+TRN-WO00034,leak slurry,Leaking
+TRN-WO00035,us,Breakdown
+TRN-WO00036,requires attention,Minor in-service problems
+TRN-WO00037,does not stop,Failure to stop on demand
+TRN-WO00038,noisy sce,Noise
+TRN-WO00039,twisting,Fail to function
+TRN-WO00040,needs to be extended,Minor in-service problems
+TRN-WO00041,lost its packing,Leaking
+TRN-WO00042,rusted through,Structural deficiency
+TRN-WO00043,needs to be held down,Minor in-service problems
+TRN-WO00044,flow issue,Plugged / choked
+TRN-WO00045,degraded,Structural deficiency
+TRN-WO00046,wont pump floc,Breakdown
+TRN-WO00047,leakspray,Leaking
+TRN-WO00048,wont run in,Failure to start on demand
+TRN-WO00049,needs repacked,Minor in-service problems
+TRN-WO00050,passing excessively,Leaking
+TRN-WO00051,blocking,Plugged / choked
+TRN-WO00052,not engaging,Failure to start on demand
+TRN-WO00053,shredded,Structural deficiency
+TRN-WO00054,noise,Noise
+TRN-WO00055,blown out,Minor in-service problems
+TRN-WO00056,needs replacing,Breakdown
+TRN-WO00057,not running,Breakdown
+TRN-WO00058,leak when shut,Leaking
+TRN-WO00059,fall off,Minor in-service problems
+TRN-WO00060,not being pumped away,Plugged / choked
+TRN-WO00061,scaled up,Minor in-service problems
+TRN-WO00062,fallen off,Minor in-service problems
+TRN-WO00063,broke away,Breakdown
+TRN-WO00064,cannot run in,Failure to start on demand
+TRN-WO00065,not pumping enough,Plugged / choked
+TRN-WO00066,not stopping,Failure to stop on demand
+TRN-WO00067,unable to shu,Failure to stop on demand
+TRN-WO00068,failed internaly,Breakdown
+TRN-WO00069,not there,Minor in-service problems
+TRN-WO00070,inefficiant,Plugged / choked
+TRN-WO00071,no reading,Abnormal instrument reading
+TRN-WO00072,will not start in,Failure to start on demand
+TRN-WO00073,been running hot,Overheating
+TRN-WO00074,fallen out,Minor in-service problems
+TRN-WO00075,leak on,Leaking
+TRN-WO00076,to be removed,Breakdown
+TRN-WO00077,unsupported,Minor in-service problems
+TRN-WO00078,giving false reading,Abnormal instrument reading
+TRN-WO00079,leak in two place,Leaking
+TRN-WO00080,not reaching flow,Plugged / choked
+TRN-WO00081,wont turn,Failure to start on demand
+TRN-WO00082,not able to open,Minor in-service problems
+TRN-WO00083,need straighting,Minor in-service problems
+TRN-WO00084,hot liquid,Overheating
+TRN-WO00085,fell apart,Minor in-service problems
+TRN-WO00086,fail again,Breakdown
+TRN-WO00087,needs to be replaced,Breakdown
+TRN-WO00088,underperforming,Low output
+TRN-WO00089,corroded close out,Structural deficiency
+TRN-WO00090,not kicking in,Failure to start on demand
+TRN-WO00091,needs to be descaled,Minor in-service problems
+TRN-WO00092,over flowed,Leaking
+TRN-WO00093,non operational,Breakdown
+TRN-WO00094,running fault,Other
+TRN-WO00095,unable to run,Failure to start on demand
+TRN-WO00096,come adrift,Minor in-service problems
+TRN-WO00097,stiff,Fail to function
+TRN-WO00098,not high enough,Low output
+TRN-WO00099,broken off,Breakdown
+TRN-WO00100,snapped,Structural deficiency
+TRN-WO00101,shorted out,Electrical
+TRN-WO00102,running when sump empty,Other
+TRN-WO00103,faul,Electrical
+TRN-WO00104,has a hole on,Structural deficiency
+TRN-WO00105,will not trip,Electrical
+TRN-WO00106,failing to start,Failure to start on demand
+TRN-WO00107,needs adjusting,Minor in-service problems
+TRN-WO00108,sheared,Structural deficiency
+TRN-WO00109,failed,Breakdown
+TRN-WO00110,no guarding,Minor in-service problems
+TRN-WO00111,unresponsive,Failure to start on demand
+TRN-WO00112,no sightglass,Minor in-service problems
+TRN-WO00113,not connected,Minor in-service problems
+TRN-WO00114,unserviceable and line,Breakdown
+TRN-WO00115,keeps triping,Electrical
+TRN-WO00116,coming out,Minor in-service problems
+TRN-WO00117,requires handle,Minor in-service problems
+TRN-WO00118,low flow,Plugged / choked
+TRN-WO00119,split,Structural deficiency
+TRN-WO00120,fail to start,Failure to start on demand
+TRN-WO00121,wont reset,Failure to start on demand
+TRN-WO00122,hard to close,Fail to close
+TRN-WO00123,hole in suction,Structural deficiency
+TRN-WO00124,worn through,Structural deficiency
+TRN-WO00125,passingleaking,Leaking
+TRN-WO00126,not opening,Minor in-service problems
+TRN-WO00127,jammedseized,Plugged / choked
+TRN-WO00128,damage,Structural deficiency
+TRN-WO00129,passing on,Leaking
+TRN-WO00130,weak,Other
+TRN-WO00131,viberating,Vibration
+TRN-WO00132,static earth resistance,Electrical
+TRN-WO00133,needs to be rebuilt,Minor in-service problems
+TRN-WO00134,needs supporting,Minor in-service problems
+TRN-WO00135,wont work,Failure to start on demand
+TRN-WO00136,wornbelt,Structural deficiency
+TRN-WO00137,not attached corroded,Minor in-service problems
+TRN-WO00138,keeps tripping,Electrical
+TRN-WO00139,weeping,Leaking
+TRN-WO00140,badly rusted,Structural deficiency
+TRN-WO00141,bad vibration,Vibration
+TRN-WO00142,fire,Overheating
+TRN-WO00143,faulting,Electrical
+TRN-WO00144,contaminating condensate,Contamination
+TRN-WO00145,too fast,High output
+TRN-WO00146,low viscosity,Contamination
+TRN-WO00147,not closing,Minor in-service problems
+TRN-WO00148,require adjusting,Minor in-service problems
+TRN-WO00149,sound,Noise
+TRN-WO00150,bent,Minor in-service problems
+TRN-WO00151,corrosion on,Structural deficiency
+TRN-WO00152,doesnt operate,Breakdown
+TRN-WO00153,seized open,Breakdown
+TRN-WO00154,excessive stopstart,Erratic output
+TRN-WO00155,needs replaceing,Breakdown
+TRN-WO00156,hot thermography,Overheating
+TRN-WO00157,erratic,Erratic output
+TRN-WO00158,false high level,Abnormal instrument reading
+TRN-WO00159,will not shut,Fail to function
+TRN-WO00160,lagging,Low output
+TRN-WO00161,blew off,Minor in-service problems
+TRN-WO00162,no fill,Minor in-service problems
+TRN-WO00163,needs packing,Minor in-service problems
+TRN-WO00164,wont pump,Breakdown
+TRN-WO00165,badly corrod,Structural deficiency
+TRN-WO00166,surging,Electrical
+TRN-WO00167,false reading,Abnormal instrument reading
+TRN-WO00168,not pumping enough to get,Plugged / choked
+TRN-WO00169,not draining,Plugged / choked
+TRN-WO00170,not wo,Breakdown
+TRN-WO00171,not charging,Electrical
+TRN-WO00172,locked,Failure to rotate
+TRN-WO00173,not moving,Plugged / choked
+TRN-WO00174,milky,Contamination
+TRN-WO00175,require tightening,Minor in-service problems
+TRN-WO00176,siezed,Breakdown
+TRN-WO00177,no pressure,Plugged / choked
+TRN-WO00178,disconnected,Breakdown
+TRN-WO00179,coming adrift,Minor in-service problems
+TRN-WO00180,ruptured,Structural deficiency
+TRN-WO00181,not pumpung,Plugged / choked
+TRN-WO00182,leakhose,Leaking
+TRN-WO00183,cracked,Structural deficiency
+TRN-WO00184,broken loose,Breakdown
+TRN-WO00185,failing,Breakdown
+TRN-WO00186,looseworn,Minor in-service problems
+TRN-WO00187,alarming eratically,Abnormal instrument reading
+TRN-WO00188,are not operational,Breakdown
+TRN-WO00189,no static,Abnormal instrument reading
+TRN-WO00190,siezed shut,Breakdown
+TRN-WO00191,running too slow,Low output
+TRN-WO00192,rusty,Structural deficiency
+TRN-WO00193,needs modifying,Minor in-service problems
+TRN-WO00194,died,Breakdown
+TRN-WO00195,smoking,Overheating
+TRN-WO00196,pulling very high,High output
+TRN-WO00197,blowin,Minor in-service problems
+TRN-WO00198,not stopping at,Failure to stop on demand
+TRN-WO00199,not operational,Breakdown
+TRN-WO00200,seizedbogged,Breakdown
+TRN-WO00201,usversicol,Breakdown
+TRN-WO00202,static,Electrical
+TRN-WO00203,does not trip,Electrical
+TRN-WO00204,needs alignment,Minor in-service problems
+TRN-WO00205,contaimination,Contamination
+TRN-WO00206,burst again,Breakdown
+TRN-WO00207,smoke,Overheating
+TRN-WO00208,losing,Minor in-service problems
+TRN-WO00209,no belt,Minor in-service problems
+TRN-WO00210,needs tightened,Minor in-service problems
+TRN-WO00211,not turning restriction,Plugged / choked
+TRN-WO00212,no signal,Abnormal instrument reading
+TRN-WO00213,emulsified,Contamination
+TRN-WO00214,alarming vibration,Vibration
+TRN-WO00215,needs patched up,Minor in-service problems
+TRN-WO00216,blew off top of,Minor in-service problems
+TRN-WO00217,badly corroded in,Structural deficiency
+TRN-WO00218,perished,Breakdown
+TRN-WO00219,need calibration,Abnormal instrument reading
+TRN-WO00220,jammed in place,Plugged / choked
+TRN-WO00221,collapsed,Breakdown
+TRN-WO00222,requires slotting,Minor in-service problems
+TRN-WO00223,fault finding,Electrical
+TRN-WO00224,reading inaccurate,Abnormal instrument reading
+TRN-WO00225,sucked in,Other
+TRN-WO00226,come loose,Minor in-service problems
+TRN-WO00227,no phase,Electrical
+TRN-WO00228,bore tripping,Electrical
+TRN-WO00229,spill to ground,Electrical
+TRN-WO00230,reading high,Abnormal instrument reading
+TRN-WO00231,rusted away,Structural deficiency
+TRN-WO00232,needs a repack,Minor in-service problems
+TRN-WO00233,fried,Breakdown
+TRN-WO00234,no speed control,Abnormal instrument reading
+TRN-WO00235,seized breakdown,Breakdown
+TRN-WO00236,needs replacement,Breakdown
+TRN-WO00237,not workin,Breakdown
+TRN-WO00238,require investigating,Minor in-service problems
+TRN-WO00239,passing when closed,Leaking
+TRN-WO00240,not operating,Breakdown
+TRN-WO00241,crack,Structural deficiency
+TRN-WO00242,stopped pumping,Spurious stop
+TRN-WO00243,not pumping issue,Plugged / choked
+TRN-WO00244,vibration,Vibration
+TRN-WO00245,no flow,Plugged / choked
+TRN-WO00246,restricted,Low output
+TRN-WO00247,high vibration,Vibration
+TRN-WO00248,unserviceable no contol,Breakdown
+TRN-WO00249,slippery,Minor in-service problems
+TRN-WO00250,no seal,Minor in-service problems
+TRN-WO00251,leak underflow,Leaking
+TRN-WO00252,blockedseized,Plugged / choked
+TRN-WO00253,broken near,Breakdown
+TRN-WO00254,faulty earth,Electrical
+TRN-WO00255,not maintaining,Plugged / choked
+TRN-WO00256,wont rotate,Failure to start on demand
+TRN-WO00257,not efficient,Low output
+TRN-WO00258,will not start,Failure to start on demand
+TRN-WO00259,contamination trip,Contamination
+TRN-WO00260,not working on,Breakdown
+TRN-WO00261,blown out at,Minor in-service problems
+TRN-WO00262,trips out,Electrical
+TRN-WO00263,struggling,Low output
+TRN-WO00264,slow,Low output
+TRN-WO00265,keeps on tripping,Electrical
+TRN-WO00266,reading stuck,Abnormal instrument reading
+TRN-WO00267,not pumping,Plugged / choked
+TRN-WO00268,torn,Structural deficiency
+TRN-WO00269,cutting in and out,Erratic output
+TRN-WO00270,leakhole,Leaking
+TRN-WO00271,come free of,Minor in-service problems
+TRN-WO00272,contaminated,Contamination
+TRN-WO00273,not pumpingeast,Plugged / choked
+TRN-WO00274,no oil movement,Plugged / choked
+TRN-WO00275,cold,Other
+TRN-WO00276,problem,Other
+TRN-WO00277,keeps tripping at start,Electrical
+TRN-WO00278,severely corroded,Structural deficiency
+TRN-WO00279,needs repack,Minor in-service problems
+TRN-WO00280,not secure,Minor in-service problems
+TRN-WO00281,missing on,Minor in-service problems
+TRN-WO00282,require changing,Minor in-service problems
+TRN-WO00283,have smoked up,Overheating
+TRN-WO00284,rusted of,Structural deficiency
+TRN-WO00285,relieving too early,Leaking
+TRN-WO00286,missing blank,Minor in-service problems
+TRN-WO00287,will not restart,Failure to start on demand
+TRN-WO00288,needs repacking,Minor in-service problems
+TRN-WO00289,high amp,Abnormal instrument reading
+TRN-WO00290,weaping,Leaking
+TRN-WO00291,burnt out,Overheating
+TRN-WO00292,blowen,Minor in-service problems
+TRN-WO00293,adrift,Minor in-service problems
+TRN-WO00294,seizes at time,Breakdown
+TRN-WO00295,may burst,Structural deficiency
+TRN-WO00296,sparaying,Leaking
+TRN-WO00297,tripping straight away,Electrical
+TRN-WO00298,has a split in,Structural deficiency
+TRN-WO00299,corrodedstripped,Structural deficiency
+TRN-WO00300,buggered,Breakdown
+TRN-WO00301,seized,Breakdown
+TRN-WO00302,pot in backward,Minor in-service problems
+TRN-WO00303,fault,Electrical
+TRN-WO00304,will not pump,Breakdown
+TRN-WO00305,tripping in,Electrical
+TRN-WO00306,requires replacing,Minor in-service problems
+TRN-WO00307,continually tripping,Electrical
+TRN-WO00308,no run indication,Abnormal instrument reading
+TRN-WO00309,running hot,Overheating
+TRN-WO00310,poor,Fail to function
+TRN-WO00311,keeps tripping out,Electrical
+TRN-WO00312,playing up,Erratic output
+TRN-WO00313,not providing pressure,Plugged / choked
+TRN-WO00314,not starting,Failure to start on demand
+TRN-WO00315,sheared off,Structural deficiency
+TRN-WO00316,not puming,Plugged / choked
+TRN-WO00317,corroding,Structural deficiency
+TRN-WO00318,spraying out of,Leaking
+TRN-WO00319,badly corroded,Structural deficiency
+TRN-WO00320,requires clean,Minor in-service problems
+TRN-WO00321,holedinspect,Structural deficiency
+TRN-WO00322,no earth,Electrical
+TRN-WO00323,missingloose,Minor in-service problems
+TRN-WO00324,siezing on,Breakdown
+TRN-WO00325,keeps kicking in,Failure to stop on demand
+TRN-WO00326,not efficiant,Low output
+TRN-WO00327,sheered,Structural deficiency
+TRN-WO00328,incorrect orientation,Minor in-service problems
+TRN-WO00329,worn out,Structural deficiency
+TRN-WO00330,signal error,Abnormal instrument reading
+TRN-WO00331,earth fault,Electrical
+TRN-WO00332,unserviceable pump,Breakdown
+TRN-WO00333,not attached,Minor in-service problems
+TRN-WO00334,leaked out,Leaking
+TRN-WO00335,shorting out,Electrical
+TRN-WO00336,tripping on overload,Electrical
+TRN-WO00337,broken,Breakdown
+TRN-WO00338,heavy corrosion,Structural deficiency
+TRN-WO00339,unable to reach,Low output
+TRN-WO00340,wont open,Fail to function
+TRN-WO00341,lealing,Leaking
+TRN-WO00342,needs another row,Minor in-service problems
+TRN-WO00343,down to earth,Electrical
+TRN-WO00344,very corroded,Structural deficiency
+TRN-WO00345,will not start after flushing,Failure to start on demand
+TRN-WO00346,slurry spraying out,Leaking
+TRN-WO00347,badly corr,Structural deficiency
+TRN-WO00348,covered,Minor in-service problems
+TRN-WO00349,requires a descale,Minor in-service problems
+TRN-WO00350,starting to crack,Structural deficiency
+TRN-WO00351,crack in transition,Structural deficiency
+TRN-WO00352,constantly losing,Leaking
+TRN-WO00353,continually trips out,Electrical
+TRN-WO00354,dirty,Minor in-service problems
+TRN-WO00355,worn again,Structural deficiency
+TRN-WO00356,broke,Breakdown
+TRN-WO00357,needs to be flushed,Minor in-service problems
+TRN-WO00358,rusted off,Structural deficiency
+TRN-WO00359,stopped working,Spurious stop
+TRN-WO00360,stuck,Fail to function
+TRN-WO00361,appears loose,Minor in-service problems
+TRN-WO00362,very high vibration,Vibration
+TRN-WO00363,cannot start,Failure to start on demand
+TRN-WO00364,not secured,Minor in-service problems
+TRN-WO00365,holed,Structural deficiency
+TRN-WO00366,jammed closed,Plugged / choked
+TRN-WO00367,tripping cause,Electrical
+TRN-WO00368,coroded,Structural deficiency
+TRN-WO00369,needs to be dismantled,Minor in-service problems
+TRN-WO00370,missing off,Minor in-service problems
+TRN-WO00371,knocking,Noise
+TRN-WO00372,slipping,Minor in-service problems
+TRN-WO00373,tripping on,Electrical
+TRN-WO00374,caught in suction,Minor in-service problems
+TRN-WO00375,defect notice,Structural deficiency
+TRN-WO00376,will not stay running,Spurious stop
+TRN-WO00377,come off,Minor in-service problems
+TRN-WO00378,tripped out,Electrical
+TRN-WO00379,not accurate,Abnormal instrument reading
+TRN-WO00380,loose,Minor in-service problems
+TRN-WO00381,has crack,Structural deficiency
+TRN-WO00382,congested,Plugged / choked
+TRN-WO00383,shows offline while running in field,Abnormal instrument reading
+TRN-WO00384,showing signs of failure,Other
+TRN-WO00385,passing,Leaking
+TRN-WO00386,broken electrical,Breakdown
+TRN-WO00387,spraying out,Leaking
+TRN-WO00388,needs freeing up,Plugged / choked
+TRN-WO00389,wont start,Failure to start on demand
+TRN-WO00390,high earth resistance,Abnormal instrument reading
+TRN-WO00391,pumping at high out put,High output
+TRN-WO00392,pinholed,Minor in-service problems
+TRN-WO00393,poor flow,Low output
+TRN-WO00394,slipped off,Minor in-service problems
+TRN-WO00395,faulty,Electrical
+TRN-WO00396,needs scope,Minor in-service problems
+TRN-WO00397,colapsed,Breakdown
+TRN-WO00398,will not run,Breakdown
+TRN-WO00399,exposed,Minor in-service problems
+TRN-WO00400,losing signal,Electrical
+TRN-WO00401,misaligning,Minor in-service problems
+TRN-WO00402,out of position,Minor in-service problems
+TRN-WO00403,need replacing,Breakdown
+TRN-WO00404,not running in,Fail to function
+TRN-WO00405,has split,Structural deficiency
+TRN-WO00406,snapped off,Structural deficiency
+TRN-WO00407,noisyvibrating,Noise
+TRN-WO00408,filled,Leaking
+TRN-WO00409,fail,Breakdown
+TRN-WO00410,fails to open in sequence,Fail to open
+TRN-WO00411,looseness,Minor in-service problems
+TRN-WO00412,too high,High output
+TRN-WO00413,blowing,Minor in-service problems
+TRN-WO00414,running when empty,Other
+TRN-WO00415,hot,Overheating
+TRN-WO00416,fluctuates at high rate,Erratic output
+TRN-WO00417,not reading right,Abnormal instrument reading
+TRN-WO00418,sitting on hot,Overheating
+TRN-WO00419,not able to maintain level,Plugged / choked
+TRN-WO00420,dislodged,Minor in-service problems
+TRN-WO00421,turning in reverse,Fail to function
+TRN-WO00422,no out put,Plugged / choked
+TRN-WO00423,leaky,Leaking
+TRN-WO00424,tripping out on run up,Electrical
+TRN-WO00425,need replaceing,Breakdown
+TRN-WO00426,not pump,Plugged / choked
+TRN-WO00427,will not run in,Breakdown
+TRN-WO00428,needs rebuild,Breakdown
+TRN-WO00429,leakingreplace,Leaking
+TRN-WO00430,stopped abruptly,Spurious stop
+TRN-WO00431,brittle,Structural deficiency
+TRN-WO00432,needs securing,Minor in-service problems
+TRN-WO00433,dented,Structural deficiency
+TRN-WO00434,vibrationlaser,Vibration
+TRN-WO00435,inconsistant flow,Plugged / choked
+TRN-WO00436,needs re build,Breakdown
+TRN-WO00437,unserviceable please replace,Breakdown
+TRN-WO00438,not connectedblanked,Minor in-service problems
+TRN-WO00439,earthing,Electrical
+TRN-WO00440,no indication,Minor in-service problems
+TRN-WO00441,stripped,Structural deficiency
+TRN-WO00442,needs inspecting,Minor in-service problems
+TRN-WO00443,snaped,Structural deficiency
+TRN-WO00444,didnt trip,Electrical
+TRN-WO00445,blow out,Minor in-service problems
+TRN-WO00446,unserviceable leak sulphur,Breakdown
+TRN-WO00447,tripping issue,Electrical
+TRN-WO00448,unable to reset,Failure to stop on demand
+TRN-WO00449,need modifying,Minor in-service problems
+TRN-WO00450,tripping out,Electrical
+TRN-WO00451,requires topupstop,Minor in-service problems
+TRN-WO00452,dragged,Minor in-service problems
+TRN-WO00453,not performingpumping,Breakdown
+TRN-WO00454,getting jammed,Plugged / choked
+TRN-WO00455,failed restest,Failure to start on demand
+TRN-WO00456,starting issue,Failure to start on demand
+TRN-WO00457,wrong range,Abnormal instrument reading
+TRN-WO00458,may be failing,Fail to function
+TRN-WO00459,stretched,Minor in-service problems
+TRN-WO00460,does dont pump at,Plugged / choked
+TRN-WO00461,stuck in open position,Fail to function
+TRN-WO00462,seize,Breakdown
+TRN-WO00463,hole in,Structural deficiency
+TRN-WO00464,snappedplugged,Structural deficiency
+TRN-WO00465,consumeing,Leaking
+TRN-WO00466,keeps vibrating shut,Vibration
+TRN-WO00467,not able to pump,Plugged / choked
+TRN-WO00468,needs a descale,Minor in-service problems
+TRN-WO00469,passing u,Leaking
+TRN-WO00470,out of adjustment,Minor in-service problems
+TRN-WO00471,failure,Breakdown
+TRN-WO00472,needs reset,Electrical
+TRN-WO00473,rupture,Structural deficiency
+TRN-WO00474,vibrating,Vibration
+TRN-WO00475,rubbing,Vibration
+TRN-WO00476,leakingneed,Leaking
+TRN-WO00477,playingup,Erratic output
+TRN-WO00478,broken into,Breakdown
+TRN-WO00479,doesnt pump to,Plugged / choked
+TRN-WO00480,corrosion,Structural deficiency
+TRN-WO00481,squealing,Noise
+TRN-WO00482,noyt pumping,Breakdown
+TRN-WO00483,fault tripping,Electrical
+TRN-WO00484,needs to be repacked,Minor in-service problems
+TRN-WO00485,will not turn,Fail to function
+TRN-WO00486,grinding,Noise
+TRN-WO00487,rusted,Structural deficiency
+TRN-WO00488,trips on overload,Electrical
+TRN-WO00489,stopping,Spurious stop
+TRN-WO00490,split in two place,Structural deficiency
+TRN-WO00491,hanging,Other
+TRN-WO00492,needs fixing,Minor in-service problems
+TRN-WO00493,detached,Minor in-service problems
+TRN-WO00494,brokenmissing,Breakdown
+TRN-WO00495,need repacking,Minor in-service problems
+TRN-WO00496,wont pump to,Breakdown
+TRN-WO00497,sce fault,Fail to function
+TRN-WO00498,wont run,Failure to start on demand
+TRN-WO00499,requires modifying,Minor in-service problems
+TRN-WO00500,requires replacement,Minor in-service problems
+TRN-WO00501,triped,Electrical
+TRN-WO00502,stopping randomly,Spurious stop


### PR DESCRIPTION
## Summary
- Add shared FCC workorder training dataset `scenarios_data/shared/work_order/fmc_train_wo.csv` (502 labeled rows; schema `wo_id, description, failure_code`).
- Repopulate `scenarios_data/shared/failure_code/failure_code_sample.csv` with the 22 distinct failure-code labels from the workorder dataset as `description`, coded `FC001`–`FC022`.

The previous `failure_code_sample.csv` held generic placeholder descriptions; this replaces them with the actual class labels used by the Failure Code Classification task. No code references the old `FC001`–`FC010` codes, so the change is safe.

Closes #361

## Test plan
- [x] `uv run pytest src/ -v -k "not integration"` — 299 passed, 10 deselected
- [x] Verified failure-code file lists all 22 distinct labels from `fmc_train_wo.csv`, no blanks, sequential `FCXXX` codes