### PR TITLE
feat(agent): add direct LLM baseline agent

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -149,7 +149,7 @@ query="What is the current date and time? Also list assets at site MAIN. Also ge
 
 ## Agents
 
-Five runners drive the same MCP servers. Each is a CLI registered by `uv sync` that takes a single positional `question` argument and spawns the MCP servers as stdio subprocesses on demand.
+Six runners are available as CLIs registered by `uv sync`; five use MCP tools, while `direct-llm-agent` is a model-only baseline that makes a direct LiteLLM call without MCP tools, planning, retrieval, or code execution. Each is a CLI registered by `uv sync` that takes a single positional `question` argument and spawns the MCP servers as stdio subprocesses on demand.
 
 | Runner         | Source                       | Loop                                                          | Default model                                               |
 | -------------- | ---------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------- |
@@ -158,6 +158,7 @@ Five runners drive the same MCP servers. Each is a CLI registered by `uv sync` t
 | `openai-agent` | `src/agent/openai_agent/`    | [`openai-agents`](https://github.com/openai/openai-agents-python) SDK Runner | `litellm_proxy/azure/gpt-5.4`                |
 | `deep-agent`   | `src/agent/deep_agent/`      | [LangChain deep-agents](https://docs.langchain.com/oss/python/deepagents/overview) (LangGraph), MCP bridged via `langchain-mcp-adapters` | `litellm_proxy/aws/claude-opus-4-6` |
 | `stirrup-agent` | `src/agent/stirrup_agent/` | [Stirrup](https://github.com/ArtificialAnalysis/Stirrup) agent loop (in-process), MCP via its `MCPToolProvider`; **code-capable** (writes/runs Python) | `watsonx/meta-llama/llama-4-maverick-17b-128e-instruct-fp8` |
+| `direct-llm-agent` | `src/agent/direct_llm_agent/` | Single direct LLM call, no MCP tools, planning, retrieval, or code execution | `litellm_proxy/Azure/gpt-5-mini-2025-08-07` |
 
 - [Agents](#agents) — Stirrup specifics in [docs/stirrup-agent.md](docs/stirrup-agent.md)
 
@@ -169,6 +170,7 @@ uv run claude-agent "$query"
 uv run openai-agent "$query"
 uv run deep-agent   "$query"
 uv run stirrup-agent "$query"
+uv run direct-llm-agent "$query"
 ```
 
 ### Common flags
@@ -216,6 +218,10 @@ uv run stirrup-agent --no-code --show-trajectory \
 # Stirrup code track in a Docker sandbox (writes and runs Python)
 STIRRUP_CODE_IMAGE=assetops-code \
   uv run stirrup-agent --code-backend docker "$query"
+
+# Direct model-only baseline, no MCP tools
+uv run direct-llm-agent --model-id litellm_proxy/Azure/gpt-5-mini-2025-08-07 \
+  'Return only JSON: {"test": 1}'
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ openai-agent = "agent.openai_agent.cli:main"
 deep-agent = "agent.deep_agent.cli:main"
 stirrup-agent = "agent.stirrup_agent.cli:main"
 evaluate = "evaluation.cli:main"
-
+direct-llm-agent = "agent.direct_llm_agent.cli:main"
 
 [dependency-groups]
 dev = [

--- a/src/agent/__init__.py
+++ b/src/agent/__init__.py
@@ -2,6 +2,7 @@
 
 from .claude_agent.runner import ClaudeAgentRunner
 from .deep_agent.runner import DeepAgentRunner
+from .direct_llm_agent.runner import DirectLLMAgentRunner
 from .models import AgentResult, ToolCall, Trajectory, TurnRecord
 from .openai_agent.runner import OpenAIAgentRunner
 from .plan_execute.models import OrchestratorResult, Plan, PlanStep, StepResult
@@ -13,6 +14,7 @@ __all__ = [
     "AgentResult",
     "ClaudeAgentRunner",
     "DeepAgentRunner",
+    "DirectLLMAgentRunner",
     "OpenAIAgentRunner",
     "OrchestratorResult",
     "Plan",

--- a/src/agent/direct_llm_agent/__init__.py
+++ b/src/agent/direct_llm_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Direct LLM baseline agent package."""
+
+from .runner import DirectLLMAgentRunner
+
+__all__ = ["DirectLLMAgentRunner"]

--- a/src/agent/direct_llm_agent/cli.py
+++ b/src/agent/direct_llm_agent/cli.py
@@ -1,0 +1,74 @@
+"""CLI entry point for the direct LLM baseline runner.
+
+Usage:
+    direct-llm-agent "Return only JSON: {\"test\": 1}"
+    direct-llm-agent --model-id litellm_proxy/Azure/gpt-5-mini-2025-08-07 "..."
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from agent._cli_common import add_common_args, print_result, run_sdk_cli
+
+_DEFAULT_MODEL = "litellm_proxy/Azure/gpt-5-mini-2025-08-07"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="direct-llm-agent",
+        description="Run a question through a direct model-only LLM baseline.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+model-id format:
+  litellm_proxy/<model>    LiteLLM proxy model
+                           e.g. litellm_proxy/Azure/gpt-5-mini-2025-08-07
+
+environment variables:
+  LITELLM_API_KEY          LiteLLM API key
+  LITELLM_BASE_URL         LiteLLM base URL
+
+examples:
+  direct-llm-agent 'Return only JSON: {"test": 1}'
+  direct-llm-agent --model-id litellm_proxy/aws/claude-opus-4-8 'Return only one integer.'
+""",
+    )
+    add_common_args(parser, default_model=_DEFAULT_MODEL)
+    return parser
+
+
+def _build_llm(model_id: str):
+    try:
+        from llm.litellm import LiteLLMBackend
+    except ImportError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        return LiteLLMBackend(model_id=model_id)
+    except KeyError as exc:
+        print(f"error: missing environment variable {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+async def _run(args: argparse.Namespace) -> None:
+    from agent.direct_llm_agent.runner import DirectLLMAgentRunner
+
+    llm = _build_llm(args.model_id)
+    runner = DirectLLMAgentRunner(llm=llm)
+    result = await runner.run(args.question)
+
+    print_result(
+        result,
+        show_trajectory=args.show_trajectory,
+        output_json=args.output_json,
+    )
+
+
+def main() -> None:
+    run_sdk_cli("direct-llm-agent", _build_parser, _run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent/direct_llm_agent/runner.py
+++ b/src/agent/direct_llm_agent/runner.py
@@ -1,0 +1,103 @@
+"""Direct LLM baseline runner.
+
+This runner does not use MCP tools, planning, code execution, or retrieval.
+It sends the benchmark question directly to the selected LLM and returns the
+model's answer. This is useful as a model-only baseline.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from llm import LLMBackend
+from observability import agent_run_span, persist_trajectory
+
+from ..models import AgentResult, Trajectory, TurnRecord
+from ..runner import AgentRunner
+
+
+_DIRECT_LLM_SYSTEM_PROMPT = """\
+You are a direct LLM baseline for AssetOpsBench.
+
+Read the user task carefully and answer in the requested format.
+You do not have access to tools, databases, workorders, sensors, or external files.
+
+If the task asks for information you cannot access, do not refuse only because
+data is missing. Use the task wording, general industrial-maintenance knowledge,
+and a reasonable guess if needed.
+
+Return only the final answer requested by the user. Do not include reasoning,
+tool-use claims, markdown, or extra explanation unless explicitly requested.
+"""
+
+
+class DirectLLMAgentRunner(AgentRunner):
+    """A simple model-only runner with no MCP tool calls."""
+
+    def __init__(
+        self,
+        llm: LLMBackend,
+        server_paths: dict[str, Path | str] | None = None,
+    ) -> None:
+        super().__init__(llm, server_paths)
+
+    async def run(self, question: str) -> AgentResult:
+        """Run one direct LLM call and return an AgentResult."""
+        with agent_run_span(
+            "direct-llm-agent",
+            model=self._llm.model_id,
+            question=question,
+        ) as span:
+            started = datetime.now(timezone.utc).isoformat()
+            run_started = time.perf_counter()
+
+            prompt = f"""{_DIRECT_LLM_SYSTEM_PROMPT}
+
+User task:
+{question}
+
+Final answer:"""
+
+            call_started = time.perf_counter()
+            result = self._llm.generate_with_usage(prompt, temperature=0.0)
+            duration_ms = (time.perf_counter() - call_started) * 1000
+            total_duration_ms = (time.perf_counter() - run_started) * 1000
+
+            answer = result.text.strip()
+
+            trajectory = Trajectory(
+                started_at=started,
+                turns=[
+                    TurnRecord(
+                        index=0,
+                        text=answer,
+                        tool_calls=[],
+                        input_tokens=result.input_tokens,
+                        output_tokens=result.output_tokens,
+                        duration_ms=duration_ms,
+                    )
+                ],
+            )
+
+            span.set_attribute("agent.answer.length", len(answer))
+            span.set_attribute("agent.duration_ms", total_duration_ms)
+            span.set_attribute("agent.llm_time_ms", duration_ms)
+            span.set_attribute("gen_ai.usage.input_tokens", result.input_tokens)
+            span.set_attribute("gen_ai.usage.output_tokens", result.output_tokens)
+            span.set_attribute("agent.tool_calls", 0)
+
+            persist_trajectory(
+                runner_name="direct-llm-agent",
+                model=self._llm.model_id,
+                question=question,
+                answer=answer,
+                trajectory=trajectory,
+            )
+
+            return AgentResult(
+                question=question,
+                answer=answer,
+                trajectory=trajectory,
+            )

--- a/src/agent/direct_llm_agent/tests/test_runner.py
+++ b/src/agent/direct_llm_agent/tests/test_runner.py
@@ -1,0 +1,32 @@
+from agent.direct_llm_agent.runner import DirectLLMAgentRunner
+
+
+class DummyLLMResult:
+    text = '{"test": 1}'
+    input_tokens = 10
+    output_tokens = 5
+
+
+class DummyLLM:
+    model_id = "dummy/direct-llm"
+
+    def generate_with_usage(self, prompt: str, temperature: float = 0.0):
+        self.prompt = prompt
+        self.temperature = temperature
+        return DummyLLMResult()
+
+
+async def test_direct_llm_agent_returns_model_answer():
+    llm = DummyLLM()
+    runner = DirectLLMAgentRunner(llm=llm)
+
+    result = await runner.run('Return only JSON: {"test": 1}')
+
+    assert result.answer == '{"test": 1}'
+    assert result.question == 'Return only JSON: {"test": 1}'
+    assert result.trajectory.total_input_tokens == 10
+    assert result.trajectory.total_output_tokens == 5
+    assert len(result.trajectory.turns) == 1
+    assert result.trajectory.turns[0].tool_calls == []
+    assert "Return only JSON" in llm.prompt
+    assert llm.temperature == 0.0


### PR DESCRIPTION
## Summary

This PR adds a direct LLM baseline agent for AssetOpsBench.

The new `direct-llm-agent` runner makes a single model call through the existing LiteLLM backend and does not use MCP tools, planning, retrieval, or code execution. This provides a simple model-only baseline for comparing against tool-augmented agents such as `stirrup-agent`.

## Changes

- Added `src/agent/direct_llm_agent/`
  - `runner.py`: implements `DirectLLMAgentRunner`
  - `cli.py`: adds the direct model-only CLI
  - `__init__.py`: exports the runner
- Registered the new CLI entry point:
  - `direct-llm-agent = "agent.direct_llm_agent.cli:main"`
- Updated the top-level agent exports to include `DirectLLMAgentRunner`

## Motivation

Some benchmark scenarios are useful to test with a direct LLM baseline, especially when we want to compare tool-using agents against a model-only response. This also avoids repeated MCP workorder retrieval and context growth for baseline runs.

## Example

```bash
uv run direct-llm-agent --model-id litellm_proxy/Azure/gpt-5-mini-2025-08-07 'Return only JSON: {"test": 1}'`


## Testing locally
```bash
uv sync --reinstall-package assetopsbench-mcp
uv run python -m agent.direct_llm_agent.cli --model-id litellm_proxy/Azure/gpt-5-mini-2025-08-07 'Return only JSON: {"test": 1}'