### PR TITLE
feat(wo): support failure_code in update_workorder

### DIFF
--- a/src/servers/wo/main.py
+++ b/src/servers/wo/main.py
@@ -181,10 +181,12 @@ async def generate_work_order(description: str, asset_num: str, site_id: str,
 
 async def update_workorder(wonum: str, site_id: str, description: Optional[str] = None,
                            priority: Optional[int] = None, location: Optional[str] = None,
-                           asset_num: Optional[str] = None, notes: Optional[str] = None
+                           asset_num: Optional[str] = None, notes: Optional[str] = None,
+                           failure_code: Optional[str] = None
                            ) -> Union[WorkOrderMutationResult, ErrorResult]:
     """Update mutable fields on a work order."""
-    res = await wo.update_workorder(db(), wonum, site_id, description, priority, location, asset_num, notes)
+    res = await wo.update_workorder(db(), wonum, site_id, description, priority, location,
+                                    asset_num, notes, failure_code)
     return _mutation(res, "updated")
 
 

--- a/src/servers/wo/tests/test_workorders.py
+++ b/src/servers/wo/tests/test_workorders.py
@@ -102,6 +102,11 @@ async def scenario():
     nf = await wo.get_workorder(db, "999", "MAIN")
     assert not nf["success"] and nf["error_code"] == "NOT_FOUND"
 
+    # partial update: failure_code set independently, other fields untouched
+    u = await wo.update_workorder(db, "1000045", "MAIN", failure_code="BRG-WEAR")
+    assert u["data"]["failurecode"] == "BRG-WEAR"
+    assert u["data"]["wopriority"] == 2, "untouched fields must survive a partial update"
+
     # approve -> assign -> close
     assert (await wo.approve_workorder(db, "1000045", "MAIN", now=T0))["data"]["status"] == "APPR"
     a = await wo.assign_technician(db, "1000045", "MAIN", "HVACTECH1", craft="HVAC",

--- a/src/servers/wo/workorders.py
+++ b/src/servers/wo/workorders.py
@@ -295,7 +295,8 @@ async def generate_work_order(db, **kwargs) -> Dict[str, Any]:
 
 async def update_workorder(db, wonum: str, site_id: str, description: Optional[str] = None,
                            priority: Optional[int] = None, location: Optional[str] = None,
-                           asset_num: Optional[str] = None, notes: Optional[str] = None) -> Dict[str, Any]:
+                           asset_num: Optional[str] = None, notes: Optional[str] = None,
+                           failure_code: Optional[str] = None) -> Dict[str, Any]:
     """Update mutable fields on an existing work order."""
     with Timer() as t:
         doc = await db.get(_doc_id(site_id, wonum))
@@ -311,6 +312,9 @@ async def update_workorder(db, wonum: str, site_id: str, description: Optional[s
             doc["assetnum"] = asset_num
         if notes is not None:
             doc["description_longdescription"] = notes
+        if failure_code is not None:
+            doc["failurecode"] = failure_code
+
         await db.put(doc)
         return envelope(_public(doc), duration_ms=t_ms(t))
 


### PR DESCRIPTION
Closes #374

## Summary
Add `failure_code` as a mutable field on `update_workorder`, so a work order's failure code can be set/changed outside of close.

## Changes
- `workorders.py`: `update_workorder` accepts `failure_code`, writes `doc["failurecode"]` (same field as `close_workorder`) using the existing `is not None` partial-update guard.
- `main.py`: expose and forward `failure_code` through the MCP tool wrapper.
- `tests/test_workorders.py`: cover partial update of `failure_code` and assert untouched fields survive.

## Testing
`uv run pytest src/servers/wo/tests/ -v -k "not integration"` → 2 passed.