### PR TITLE
Updating collections.json

### DIFF
--- a/src/couchdb/collections.json
+++ b/src/couchdb/collections.json
@@ -77,7 +77,7 @@
             ]
         ]
     },
-    "failurecode": {
+    "failure_code": {
         "format": "csv",
         "primary_key": [
             "code"


### PR DESCRIPTION
## Summary
Updates CouchDB collection naming so scenario-suite manifests load the failure-code CSV correctly.

## Changes
- Updated `src/couchdb/collections.json`
- Aligned the failure-code collection key with the scenario manifest naming
- Ensured scenario-suite CouchDB reload works for scenario 301 and similar cases

## Why
Scenario-suite execution failed because the manifest key and CouchDB collection config did not match. The loader treated the failure-code file with the wrong parser and crashed during initialization.

## Result
Scenario 301 now loads correctly, and benchmark batch runs can reset and reload CouchDB without hitting the CSV/JSON parsing mismatch.

## Testing
- Ran `couchdb.init_data.py` for scenario 301
- Verified `failure_code.csv` is loaded successfully
- Verified benchmark runner continues past CouchDB initialization