### PR TITLE
Strip <think> blocks before evaluation

### DIFF
--- a/src/evaluation/evaluator.py
+++ b/src/evaluation/evaluator.py
@@ -28,12 +28,7 @@ _log = logging.getLogger(__name__)
 
 
 class Evaluator:
-    """Run a batch of scenarios against their saved trajectories.
-
-    ``default_scorer`` names the registered scorer to use when a
-    scenario does not set ``scoring_method``.  Per-scenario overrides
-    take precedence.
-    """
+    """Run a batch of scenarios against their saved trajectories."""
 
     def __init__(
         self,

--- a/src/evaluation/evaluator.py
+++ b/src/evaluation/evaluator.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from pathlib import Path
 
 from . import scorers as scorer_registry
@@ -64,7 +65,8 @@ class Evaluator:
         scorer = self._resolve(name)
         self._validate_judge_model(name, traj)
         trajectory_text = _trajectory_to_text(traj)
-        score = scorer(scenario, traj.answer, trajectory_text)
+        answer = _strip_think_blocks(traj.answer)
+        score = scorer(scenario, answer, trajectory_text)
 
         return ScenarioResult(
             scenario_id=scenario.id,
@@ -73,7 +75,7 @@ class Evaluator:
             runner=traj.runner,
             model=traj.model,
             question=traj.question,
-            answer=traj.answer,
+            answer=answer,
             score=score,
             ops=metrics_from_trajectory(traj),
         )
@@ -106,6 +108,16 @@ def _trajectory_to_text(traj: PersistedTrajectory) -> str:
         return json.dumps(traj.trajectory, indent=2, default=str)
     except (TypeError, ValueError):
         return str(traj.trajectory)
+
+
+def _strip_think_blocks(answer: str) -> str:
+    """Remove model-private <think>...</think> blocks before scoring."""
+    return re.sub(
+        r"<think\b[^>]*>.*?</think>",
+        "",
+        answer,
+        flags=re.IGNORECASE | re.DOTALL,
+    ).strip()
 
 
 def _normalize_model_id(model_id: str | None) -> str:

--- a/src/evaluation/tests/test_evaluator.py
+++ b/src/evaluation/tests/test_evaluator.py
@@ -79,8 +79,6 @@ def _fail_scorer(scenario: Scenario, answer: str, trajectory_text: str) -> Score
 
 
 def test_evaluator_per_scenario_override_wins(tmp_path: Path, make_persisted_record):
-    # The scenario-level scoring_method must route around the default
-    # scorer, even when the default scorer would reject the answer.
     rec = make_persisted_record(run_id="run-1", scenario_id=1, answer="answer text")
     (tmp_path / "run-1.json").write_text(json.dumps(rec), encoding="utf-8")
 
@@ -98,3 +96,111 @@ def test_evaluator_per_scenario_override_wins(tmp_path: Path, make_persisted_rec
         ),
         encoding="utf-8",
     )
+
+    registry.register("stub-evaluator", _stub_scorer)
+    registry.register("fail-default", _fail_scorer)
+
+    report = Evaluator(default_scorer="fail-default").evaluate(
+        trajectories_path=tmp_path,
+        scenarios_paths=[scenarios_path],
+    )
+
+    assert report.totals["passed"] == 1
+    assert report.results[0].score.scorer == "stub-evaluator"
+
+
+def test_evaluator_rejects_self_judging_model(tmp_path: Path, make_persisted_record):
+    trajectories_dir = tmp_path / "trajectories"
+    trajectories_dir.mkdir()
+
+    rec = make_persisted_record(
+        run_id="run-1",
+        scenario_id=1,
+        model="litellm_proxy/aws/claude-opus-4-6",
+    )
+    (trajectories_dir / "run-1.json").write_text(json.dumps(rec), encoding="utf-8")
+
+    scenarios_path = tmp_path / "scenarios.json"
+    scenarios_path.write_text(
+        json.dumps([{"id": 1, "text": "Q", "type": "iot"}]),
+        encoding="utf-8",
+    )
+
+    registry.register("llm_judge", _stub_scorer)
+
+    try:
+        Evaluator(
+            default_scorer="llm_judge",
+            judge_model="litellm_proxy/aws/claude-opus-4-6",
+        ).evaluate(
+            trajectories_path=trajectories_dir,
+            scenarios_paths=[scenarios_path],
+        )
+    except ValueError as exc:
+        assert "self-judging is not allowed" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for self-judging")
+
+
+def test_evaluator_rejects_self_judging_with_normalized_model_ids(
+    tmp_path: Path, make_persisted_record
+):
+    trajectories_dir = tmp_path / "trajectories"
+    trajectories_dir.mkdir()
+
+    rec = make_persisted_record(
+        run_id="run-1",
+        scenario_id=1,
+        model="litellm_proxy/aws/claude-opus-4-6",
+    )
+    (trajectories_dir / "run-1.json").write_text(json.dumps(rec), encoding="utf-8")
+
+    scenarios_path = tmp_path / "scenarios.json"
+    scenarios_path.write_text(
+        json.dumps([{"id": 1, "text": "Q", "type": "iot"}]),
+        encoding="utf-8",
+    )
+
+    registry.register("llm_judge", _stub_scorer)
+
+    try:
+        Evaluator(
+            default_scorer="llm_judge",
+            judge_model="aws/claude-opus-4-6",
+        ).evaluate(
+            trajectories_path=trajectories_dir,
+            scenarios_paths=[scenarios_path],
+        )
+    except ValueError as exc:
+        assert "self-judging is not allowed" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for self-judging")
+
+
+def test_evaluator_allows_non_llm_judge_even_with_matching_model(
+    tmp_path: Path, make_persisted_record
+):
+    rec = make_persisted_record(
+        run_id="run-1",
+        scenario_id=1,
+        model="litellm_proxy/aws/claude-opus-4-6",
+    )
+    (tmp_path / "run-1.json").write_text(json.dumps(rec), encoding="utf-8")
+
+    scenarios_path = tmp_path / "scenarios.json"
+    scenarios_path.write_text(
+        json.dumps([{"id": 1, "text": "Q", "type": "iot"}]),
+        encoding="utf-8",
+    )
+
+    registry.register("stub-evaluator", _stub_scorer)
+
+    report = Evaluator(
+        default_scorer="stub-evaluator",
+        judge_model="aws/claude-opus-4-6",
+    ).evaluate(
+        trajectories_path=tmp_path,
+        scenarios_paths=[scenarios_path],
+    )
+
+    assert report.totals["passed"] == 1

--- a/src/evaluation/tests/test_evaluator.py
+++ b/src/evaluation/tests/test_evaluator.py
@@ -35,6 +35,45 @@ def test_evaluator_routes_to_default_scorer(tmp_path: Path, make_persisted_recor
     assert report.results[0].score.scorer == "stub-evaluator"
 
 
+def test_evaluator_strips_think_blocks_before_scoring(
+    tmp_path: Path, make_persisted_record
+):
+    seen: dict[str, str] = {}
+
+    def capture_scorer(
+        scenario: Scenario, answer: str, trajectory_text: str
+    ) -> ScorerResult:
+        seen["answer"] = answer
+        return ScorerResult(scorer="capture-evaluator", passed=True, score=1.0)
+
+    rec = make_persisted_record(
+        run_id="run-1",
+        scenario_id=1,
+        answer=(
+            "<think>I should inspect the work orders.</think>\n\n"
+            "<think>There are no kit entries.</think>\n\n"
+            "0"
+        ),
+    )
+    (tmp_path / "run-1.json").write_text(json.dumps(rec), encoding="utf-8")
+
+    scenarios_path = tmp_path / "scenarios.json"
+    scenarios_path.write_text(
+        json.dumps([{"id": 1, "text": "Q", "type": "wo"}]),
+        encoding="utf-8",
+    )
+
+    registry.register("capture-evaluator", capture_scorer)
+
+    report = Evaluator(default_scorer="capture-evaluator").evaluate(
+        trajectories_path=tmp_path,
+        scenarios_paths=[scenarios_path],
+    )
+
+    assert seen["answer"] == "0"
+    assert report.results[0].answer == "0"
+
+
 def _fail_scorer(scenario: Scenario, answer: str, trajectory_text: str) -> ScorerResult:
     return ScorerResult(scorer="fail-default", passed=False, score=0.0)
 
@@ -59,111 +98,3 @@ def test_evaluator_per_scenario_override_wins(tmp_path: Path, make_persisted_rec
         ),
         encoding="utf-8",
     )
-
-    registry.register("stub-evaluator", _stub_scorer)
-    registry.register("fail-default", _fail_scorer)
-
-    report = Evaluator(default_scorer="fail-default").evaluate(
-        trajectories_path=tmp_path,
-        scenarios_paths=[scenarios_path],
-    )
-
-    assert report.totals["passed"] == 1
-    assert report.results[0].score.scorer == "stub-evaluator"
-
-
-def test_evaluator_rejects_self_judging_model(tmp_path: Path, make_persisted_record):
-    trajectories_dir = tmp_path / "trajectories"
-    trajectories_dir.mkdir()
-
-    rec = make_persisted_record(
-        run_id="run-1",
-        scenario_id=1,
-        model="litellm_proxy/aws/claude-opus-4-6",
-    )
-    (trajectories_dir / "run-1.json").write_text(json.dumps(rec), encoding="utf-8")
-
-    scenarios_path = tmp_path / "scenarios.json"
-    scenarios_path.write_text(
-        json.dumps([{"id": 1, "text": "Q", "type": "iot"}]),
-        encoding="utf-8",
-    )
-
-    registry.register("llm_judge", _stub_scorer)
-
-    try:
-        Evaluator(
-            default_scorer="llm_judge",
-            judge_model="litellm_proxy/aws/claude-opus-4-6",
-        ).evaluate(
-            trajectories_path=trajectories_dir,
-            scenarios_paths=[scenarios_path],
-        )
-    except ValueError as exc:
-        assert "self-judging is not allowed" in str(exc)
-    else:
-        raise AssertionError("expected ValueError for self-judging")
-
-
-def test_evaluator_rejects_self_judging_with_normalized_model_ids(
-    tmp_path: Path, make_persisted_record
-):
-    trajectories_dir = tmp_path / "trajectories"
-    trajectories_dir.mkdir()
-
-    rec = make_persisted_record(
-        run_id="run-1",
-        scenario_id=1,
-        model="litellm_proxy/aws/claude-opus-4-6",
-    )
-    (trajectories_dir / "run-1.json").write_text(json.dumps(rec), encoding="utf-8")
-
-    scenarios_path = tmp_path / "scenarios.json"
-    scenarios_path.write_text(
-        json.dumps([{"id": 1, "text": "Q", "type": "iot"}]),
-        encoding="utf-8",
-    )
-
-    registry.register("llm_judge", _stub_scorer)
-
-    try:
-        Evaluator(
-            default_scorer="llm_judge",
-            judge_model="aws/claude-opus-4-6",
-        ).evaluate(
-            trajectories_path=trajectories_dir,
-            scenarios_paths=[scenarios_path],
-        )
-    except ValueError as exc:
-        assert "self-judging is not allowed" in str(exc)
-    else:
-        raise AssertionError("expected ValueError for self-judging")
-
-
-def test_evaluator_allows_non_llm_judge_even_with_matching_model(
-    tmp_path: Path, make_persisted_record
-):
-    rec = make_persisted_record(
-        run_id="run-1",
-        scenario_id=1,
-        model="litellm_proxy/aws/claude-opus-4-6",
-    )
-    (tmp_path / "run-1.json").write_text(json.dumps(rec), encoding="utf-8")
-
-    scenarios_path = tmp_path / "scenarios.json"
-    scenarios_path.write_text(
-        json.dumps([{"id": 1, "text": "Q", "type": "iot"}]),
-        encoding="utf-8",
-    )
-
-    registry.register("stub-evaluator", _stub_scorer)
-
-    report = Evaluator(
-        default_scorer="stub-evaluator",
-        judge_model="aws/claude-opus-4-6",
-    ).evaluate(
-        trajectories_path=tmp_path,
-        scenarios_paths=[scenarios_path],
-    )
-
-    assert report.totals["passed"] == 1


### PR DESCRIPTION
## Summary
This PR updates the evaluation flow to remove model reasoning blocks wrapped in `<think>...</think>` before scoring agent answers. This ensures the evaluator scores only the actual final answer, which improves reliability for strict-answer tasks such as integer counts and JSON outputs.

## Changes
- Added answer normalization in `src/evaluation/evaluator.py`.
- Introduced `_strip_think_blocks()` to remove `<think>...</think>` content.
- Updated evaluation to pass the cleaned answer to the scorer.
- Reports now store the cleaned answer used for scoring.

## Why
Without this cleanup, evaluation may include reasoning text that is not part of the requested answer. This can cause incorrect scoring even when the final answer is present after the think block.

## Testing
- Verified that answers with `<think>...</think>` blocks are cleaned before scoring.
- Verified that answers without think blocks continue to evaluate normally.