### PR TITLE
Fix TokenRouter Claude OpenCode protocol

### DIFF
--- a/src/agent/opencode_agent/cli.py
+++ b/src/agent/opencode_agent/cli.py
@@ -35,7 +35,7 @@ environment variables:
   LITELLM_API_KEY         LiteLLM router key for litellm_proxy/* models
   LITELLM_BASE_URL        LiteLLM OpenAI-compatible base URL
   TOKENROUTER_API_KEY     TokenRouter key for tokenrouter/* models
-  TOKENROUTER_BASE_URL    TokenRouter OpenAI-compatible base URL
+  TOKENROUTER_BASE_URL    TokenRouter base URL; Claude models use Anthropic protocol
 
 examples:
   opencode-agent "What assets are at site MAIN?"

--- a/src/agent/opencode_agent/runner.py
+++ b/src/agent/opencode_agent/runner.py
@@ -115,8 +115,9 @@ def _resolve_opencode_model_and_provider(
     """Translate AssetOpsBench router model IDs into OpenCode config.
 
     OpenCode wants ``provider/model``.  For AssetOpsBench router prefixes such
-    as ``litellm_proxy/`` and ``tokenrouter/``, declare a custom
-    OpenAI-compatible provider and register the requested model explicitly.
+    as ``litellm_proxy/`` and ``tokenrouter/``, declare a custom provider and
+    register the requested model explicitly. TokenRouter Claude models need the
+    Anthropic protocol so OpenCode preserves native Anthropic message handling.
     """
     creds = resolve_router_creds(model_id, strict=True)
     if creds is None:
@@ -126,9 +127,14 @@ def _resolve_opencode_model_and_provider(
     provider_name = "TokenRouter" if provider_id == "tokenrouter" else "LiteLLM Proxy"
     model_name = resolve_model(model_id)
     opencode_model = f"{provider_id}/{model_name}"
+    provider_npm = (
+        "@ai-sdk/anthropic"
+        if provider_id == "tokenrouter" and model_name.startswith("anthropic/")
+        else "@ai-sdk/openai-compatible"
+    )
     provider = {
         provider_id: {
-            "npm": "@ai-sdk/openai-compatible",
+            "npm": provider_npm,
             "name": provider_name,
             "options": {
                 "baseURL": creds.base_url,

--- a/src/agent/opencode_agent/runner.py
+++ b/src/agent/opencode_agent/runner.py
@@ -401,7 +401,9 @@ def _merge_text(existing: str, new: str) -> str:
     return existing + new
 
 
-def _is_step_finish(event: dict[str, Any], part: dict[str, Any], part_type: str) -> bool:
+def _is_step_finish(
+    event: dict[str, Any], part: dict[str, Any], part_type: str
+) -> bool:
     """True for OpenCode step-finish boundaries."""
     event_type = str(event.get("type") or "").lower()
     return ("step" in part_type and "finish" in part_type) or (
@@ -549,10 +551,9 @@ def _build_trajectory_from_events(
                     output_tokens=step["output_tokens"],
                 )
             )
-        if (
-            sum(step["input_tokens"] + step["output_tokens"] for step in steps) == 0
-            and (total_input or total_output)
-        ):
+        if sum(
+            step["input_tokens"] + step["output_tokens"] for step in steps
+        ) == 0 and (total_input or total_output):
             trajectory.turns[-1].input_tokens = total_input
             trajectory.turns[-1].output_tokens = total_output
         trajectory.turns[-1].duration_ms = duration_ms

--- a/src/agent/opencode_agent/tests/test_runner.py
+++ b/src/agent/opencode_agent/tests/test_runner.py
@@ -108,19 +108,27 @@ def test_resolve_litellm_model(monkeypatch):
     assert model == "litellm-proxy/azure/gpt-5.4"
     assert provider["litellm-proxy"]["npm"] == "@ai-sdk/openai-compatible"
     assert provider["litellm-proxy"]["options"]["baseURL"] == "http://localhost:4000"
-    assert provider["litellm-proxy"]["models"]["azure/gpt-5.4"]["name"] == "azure/gpt-5.4"
-    assert env["ASSETOPSBENCH_OPENCODE_API_KEY"] == "sk-test" # pragma: allowlist secret
+    assert (
+        provider["litellm-proxy"]["models"]["azure/gpt-5.4"]["name"] == "azure/gpt-5.4"
+    )
+    assert (
+        env["ASSETOPSBENCH_OPENCODE_API_KEY"] == "sk-test"
+    )  # pragma: allowlist secret
 
 
 def test_resolve_tokenrouter_model(monkeypatch):
     monkeypatch.setenv("TOKENROUTER_BASE_URL", "https://router.example/v1")
     monkeypatch.setenv("TOKENROUTER_API_KEY", "tr-test")
-    model, provider, env = _resolve_opencode_model_and_provider("tokenrouter/MiniMax-M3")
+    model, provider, env = _resolve_opencode_model_and_provider(
+        "tokenrouter/MiniMax-M3"
+    )
     assert model == "tokenrouter/MiniMax-M3"
     assert provider["tokenrouter"]["npm"] == "@ai-sdk/openai-compatible"
     assert provider["tokenrouter"]["options"]["baseURL"] == "https://router.example/v1"
     assert provider["tokenrouter"]["models"]["MiniMax-M3"]["name"] == "MiniMax-M3"
-    assert env["ASSETOPSBENCH_OPENCODE_API_KEY"] == "tr-test" # pragma: allowlist secret
+    assert (
+        env["ASSETOPSBENCH_OPENCODE_API_KEY"] == "tr-test"
+    )  # pragma: allowlist secret
 
 
 def test_resolve_tokenrouter_anthropic_model(monkeypatch):
@@ -136,7 +144,9 @@ def test_resolve_tokenrouter_anthropic_model(monkeypatch):
         provider["tokenrouter"]["models"]["anthropic/claude-opus-4.8"]["name"]
         == "anthropic/claude-opus-4.8"
     )
-    assert env["ASSETOPSBENCH_OPENCODE_API_KEY"] == "tr-test" # pragma: allowlist secret
+    assert (
+        env["ASSETOPSBENCH_OPENCODE_API_KEY"] == "tr-test"
+    )  # pragma: allowlist secret
 
 
 def test_build_opencode_config_includes_agent_and_mcp():
@@ -255,13 +265,14 @@ def test_runner_workspace_mode(tmp_path):
     assert runner._run_dir == workspace.resolve()
     assert runner._config["agent"]["assetops"]["permission"]["read"] == "allow"
 
+
 def _text_part(part_id, text, *, message_id=None, part_type="text"):
     part = {"id": part_id, "type": part_type, "text": text}
     if message_id is not None:
         part["messageID"] = message_id
     return {"type": "message.part.updated", "properties": {"part": part}}
- 
- 
+
+
 def _tool_part(part_id, tool, *, input=None, output=None):
     return {
         "type": "message.part.updated",
@@ -275,8 +286,8 @@ def _tool_part(part_id, tool, *, input=None, output=None):
             }
         },
     }
- 
- 
+
+
 def _step_finish(input_tokens, output_tokens):
     return {
         "type": "step_finish",
@@ -285,8 +296,8 @@ def _step_finish(input_tokens, output_tokens):
             "tokens": {"input": input_tokens, "output": output_tokens},
         },
     }
- 
- 
+
+
 def test_answer_excludes_intermediate_narration():
     """Only the final assistant message is the answer, not scratch talk."""
     events = [
@@ -302,8 +313,8 @@ def test_answer_excludes_intermediate_narration():
     assert len(trajectory.all_tool_calls) == 1
     assert trajectory.total_input_tokens == 110
     assert trajectory.total_output_tokens == 13
- 
- 
+
+
 def test_answer_excludes_reasoning_parts():
     events = [
         _text_part("r1", "(internal) suspect bearing wear", part_type="reasoning"),
@@ -311,8 +322,8 @@ def test_answer_excludes_reasoning_parts():
     ]
     answer, _ = _build_trajectory_from_events(events, [])
     assert answer == "The pump is healthy."
- 
- 
+
+
 def test_parallel_tool_calls_keep_their_own_outputs():
     """Two tool calls emitted before their outputs must not be mismatched."""
     events = [
@@ -324,8 +335,8 @@ def test_parallel_tool_calls_keep_their_own_outputs():
     by_name = {tc.name: tc.output for tc in trajectory.all_tool_calls}
     assert by_name["get_temp"] == "temp=42"
     assert by_name["get_vibration"] == "vib=0.3"
- 
- 
+
+
 def test_text_deltas_are_reconstructed():
     snapshot = [
         _text_part("t1", "Chiller 6 "),
@@ -337,4 +348,3 @@ def test_text_deltas_are_reconstructed():
     ]
     assert _build_trajectory_from_events(snapshot, [])[0] == "Chiller 6 has 5 sensors."
     assert _build_trajectory_from_events(delta, [])[0] == "Chiller 6 has 5 sensors."
- 

--- a/src/agent/opencode_agent/tests/test_runner.py
+++ b/src/agent/opencode_agent/tests/test_runner.py
@@ -123,6 +123,22 @@ def test_resolve_tokenrouter_model(monkeypatch):
     assert env["ASSETOPSBENCH_OPENCODE_API_KEY"] == "tr-test" # pragma: allowlist secret
 
 
+def test_resolve_tokenrouter_anthropic_model(monkeypatch):
+    monkeypatch.setenv("TOKENROUTER_BASE_URL", "https://router.example/v1")
+    monkeypatch.setenv("TOKENROUTER_API_KEY", "tr-test")
+    model, provider, env = _resolve_opencode_model_and_provider(
+        "tokenrouter/anthropic/claude-opus-4.8"
+    )
+    assert model == "tokenrouter/anthropic/claude-opus-4.8"
+    assert provider["tokenrouter"]["npm"] == "@ai-sdk/anthropic"
+    assert provider["tokenrouter"]["options"]["baseURL"] == "https://router.example/v1"
+    assert (
+        provider["tokenrouter"]["models"]["anthropic/claude-opus-4.8"]["name"]
+        == "anthropic/claude-opus-4.8"
+    )
+    assert env["ASSETOPSBENCH_OPENCODE_API_KEY"] == "tr-test" # pragma: allowlist secret
+
+
 def test_build_opencode_config_includes_agent_and_mcp():
     config, env, opencode_model = _build_opencode_config(
         model="opencode/gpt-5",


### PR DESCRIPTION
## Description
Configure OpenCode to use the Anthropic AI SDK protocol for TokenRouter Claude models instead of routing those requests through the OpenAI-compatible provider.

## Fix Details
- Detect `tokenrouter/anthropic/...` model IDs in the OpenCode runner provider config.
- Use `@ai-sdk/anthropic` for those Claude models while keeping other router models on `@ai-sdk/openai-compatible`.
- Add unit coverage for `tokenrouter/anthropic/claude-opus-4.8`.
- Update CLI help to describe the TokenRouter Claude protocol behavior.

## Impact on Benchmarking
- [x] **No change to baselines**: This fix only improves stability/performance.
- [ ] **Baseline change**: This fix corrects a scoring error. (Please provide "Before vs. After" results).

## Related Issues
- Fixes: #426

## Verification Steps
1. Run the following command: `uv run pytest src/agent/opencode_agent/tests/test_runner.py -v`
2. Focused OpenCode runner tests passed: 21 passed.
3. Run Ruff on touched files: `uvx ruff check ...` and `uvx ruff format --check ...`
4. Ruff passed: all checks passed, 3 files already formatted.
5. `uv run pytest src/ -v -k "not integration"` was also run from a clean worktree, but failed on unrelated existing issues outside this change path: direct LLM JSON spacing, missing `google.protobuf` for observability file exporter tests, and an IoT mock DB assertion.

## Checklist
- [x] I have added tests that prove my fix is effective.
- [x] My code follows the project's Ruff formatting and linting rules.
- [x] I have signed off my commits (DCO).
