### PR TITLE
Add structured evaluation metrics

### DIFF
--- a/src/evaluation/report.py
+++ b/src/evaluation/report.py
@@ -33,16 +33,27 @@ def _aggregate_score_summary(results: list[ScenarioResult]) -> dict[str, Any]:
     numeric metrics and count totals across the full batch.
     """
     metric_names = [
+        "partial_match_accuracy",
         "partial_exact_match_accuracy",
         "strict_exact_match_accuracy",
         "partial_similarity_score",
+        "partial_numeric_match_accuracy",
+        "range_match_accuracy",
+        "delta_1_match_accuracy",
         "precision",
         "recall",
         "f1",
         "total_gold_keys",
         "total_model_keys",
         "matched_keys",
+        "accepted_value_matches",
         "exact_value_matches",
+        "numeric_gold_keys",
+        "numeric_value_matches",
+        "range_eligible_keys",
+        "range_value_matches",
+        "delta_1_eligible_keys",
+        "delta_1_value_matches",
     ]
 
     score_values: dict[str, list[float]] = {name: [] for name in metric_names}
@@ -87,16 +98,29 @@ def _aggregate_score_summary(results: list[ScenarioResult]) -> dict[str, Any]:
         "score_avg": _avg(score_values["score"]),
         "score_min": round(min(score_values["score"]), 4) if score_values["score"] else None,
         "score_max": round(max(score_values["score"]), 4) if score_values["score"] else None,
+        "partial_match_accuracy_avg": _avg(score_values["partial_match_accuracy"]),
         "partial_exact_match_accuracy_avg": _avg(score_values["partial_exact_match_accuracy"]),
         "strict_exact_match_accuracy_avg": _avg(score_values["strict_exact_match_accuracy"]),
         "partial_similarity_score_avg": _avg(score_values["partial_similarity_score"]),
+        "partial_numeric_match_accuracy_avg": _avg(
+            score_values["partial_numeric_match_accuracy"]
+        ),
+        "range_match_accuracy_avg": _avg(score_values["range_match_accuracy"]),
+        "delta_1_match_accuracy_avg": _avg(score_values["delta_1_match_accuracy"]),
         "precision_avg": _avg(score_values["precision"]),
         "recall_avg": _avg(score_values["recall"]),
         "f1_avg": _avg(score_values["f1"]),
         "total_gold_keys_avg": _avg(score_values["total_gold_keys"]),
         "total_model_keys_avg": _avg(score_values["total_model_keys"]),
         "matched_keys_avg": _avg(score_values["matched_keys"]),
+        "accepted_value_matches_avg": _avg(score_values["accepted_value_matches"]),
         "exact_value_matches_avg": _avg(score_values["exact_value_matches"]),
+        "numeric_gold_keys_avg": _avg(score_values["numeric_gold_keys"]),
+        "numeric_value_matches_avg": _avg(score_values["numeric_value_matches"]),
+        "range_eligible_keys_avg": _avg(score_values["range_eligible_keys"]),
+        "range_value_matches_avg": _avg(score_values["range_value_matches"]),
+        "delta_1_eligible_keys_avg": _avg(score_values["delta_1_eligible_keys"]),
+        "delta_1_value_matches_avg": _avg(score_values["delta_1_value_matches"]),
         "missing_keys_total": missing_keys_total,
         "extra_keys_total": extra_keys_total,
         "detail_entries_total": detail_entries_total,
@@ -189,6 +213,10 @@ def render_summary(report: EvalReport) -> str:
             lines.append(f"  score_min:                  {s['score_min']:.4f}")
         if s.get("score_max") is not None:
             lines.append(f"  score_max:                  {s['score_max']:.4f}")
+        if s.get("partial_match_accuracy_avg") is not None:
+            lines.append(
+                f"  partial_match_avg:           {s['partial_match_accuracy_avg']:.4f}"
+            )
         if s.get("partial_exact_match_accuracy_avg") is not None:
             lines.append(
                 f"  partial_exact_match_avg:     {s['partial_exact_match_accuracy_avg']:.4f}"
@@ -200,6 +228,18 @@ def render_summary(report: EvalReport) -> str:
         if s.get("partial_similarity_score_avg") is not None:
             lines.append(
                 f"  partial_similarity_avg:      {s['partial_similarity_score_avg']:.4f}"
+            )
+        if s.get("partial_numeric_match_accuracy_avg") is not None:
+            lines.append(
+                f"  partial_numeric_match_avg:   {s['partial_numeric_match_accuracy_avg']:.4f}"
+            )
+        if s.get("range_match_accuracy_avg") is not None:
+            lines.append(
+                f"  range_match_avg:             {s['range_match_accuracy_avg']:.4f}"
+            )
+        if s.get("delta_1_match_accuracy_avg") is not None:
+            lines.append(
+                f"  delta_1_match_avg:           {s['delta_1_match_accuracy_avg']:.4f}"
             )
         if s.get("precision_avg") is not None:
             lines.append(f"  precision_avg:               {s['precision_avg']:.4f}")

--- a/src/evaluation/scorers/static_json.py
+++ b/src/evaluation/scorers/static_json.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import ast
 import json
+import math
 import re
 from dataclasses import asdict, dataclass, field
 from typing import Any
@@ -38,22 +39,37 @@ class KeyComparison:
     exact: bool
     match_type: str
     similarity: float
+    accepted: bool
+    numeric: bool = False
+    range_match: bool | None = None
+    delta_1_match: bool | None = None
 
 
 @dataclass
 class StaticJsonScore:
     """Structured score for one gold/model answer pair."""
 
+    partial_match_accuracy: float
     partial_exact_match_accuracy: float
     strict_exact_match_accuracy: float
     partial_similarity_score: float
+    partial_numeric_match_accuracy: float
+    range_match_accuracy: float
+    delta_1_match_accuracy: float
     precision: float
     recall: float
     f1: float
     total_gold_keys: int
     total_model_keys: int
     matched_keys: int
+    accepted_value_matches: int
     exact_value_matches: int
+    numeric_gold_keys: int
+    numeric_value_matches: int
+    range_eligible_keys: int
+    range_value_matches: int
+    delta_1_eligible_keys: int
+    delta_1_value_matches: int
     missing_keys: list[str] = field(default_factory=list)
     extra_keys: list[str] = field(default_factory=list)
     details: list[KeyComparison] = field(default_factory=list)
@@ -166,7 +182,10 @@ def _extract_count_from_text(content: str) -> int | float | None:
     if re.fullmatch(r"-?\d+\.\d+", stripped):
         return float(stripped)
 
-    numbers = re.findall(r"-?\d+(?:\.\d+)?", stripped)
+    numbers = re.findall(
+        r"(?<![A-Za-z0-9_])-?\d+(?:\.\d+)?(?![A-Za-z0-9_])",
+        stripped,
+    )
     if len(numbers) == 1:
         number = numbers[0]
         return float(number) if "." in number else int(number)
@@ -289,6 +308,184 @@ def similarity_score(gold_value: str, model_value: str) -> float:
     return score
 
 
+_NUMBER_RE = r"[+-]?\d+(?:\.\d+)?"
+_RANGE_FIELD_PAIRS = (
+    ("start_point", "end_point"),
+    ("start", "end"),
+    ("start_time", "end_time"),
+    ("start_timestamp", "end_timestamp"),
+    ("min", "max"),
+    ("minimum", "maximum"),
+    ("lower", "upper"),
+    ("lower_bound", "upper_bound"),
+    ("range_start", "range_end"),
+)
+
+
+@dataclass(frozen=True)
+class _ValueComparison:
+    exact: bool
+    accepted: bool
+    match_type: str
+    similarity: float
+    numeric: bool
+    numeric_match: bool
+    range_eligible: bool
+    range_match: bool | None
+    delta_1_eligible: bool
+    delta_1_match: bool | None
+
+
+def _as_float(value: str) -> float | None:
+    """Parse a normalized scalar value as a finite float when possible."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isfinite(number):
+        return number
+    return None
+
+
+def _normalize_range(left: float, right: float) -> tuple[float, float]:
+    return (left, right) if left <= right else (right, left)
+
+
+def _extract_numeric_range(value: str) -> tuple[float, float] | None:
+    """Parse simple range strings such as ``240-511`` or ``between 3 and 7``."""
+    value = value.strip().lower()
+
+    patterns = [
+        rf"^({_NUMBER_RE})\s*(?:\.\.|-|to|through|,|–|—)\s*({_NUMBER_RE})$",
+        rf"^between\s+({_NUMBER_RE})\s+and\s+({_NUMBER_RE})$",
+        rf"^(?:min|minimum|lower|start)\s*[:=]\s*({_NUMBER_RE}).*"
+        rf"(?:max|maximum|upper|end)\s*[:=]\s*({_NUMBER_RE})$",
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, value)
+        if not match:
+            continue
+        left = _as_float(match.group(1))
+        right = _as_float(match.group(2))
+        if left is not None and right is not None:
+            return _normalize_range(left, right)
+
+    return None
+
+
+def _split_flat_key(key: str) -> tuple[str, str] | None:
+    if "." not in key:
+        return None
+    parent, field_name = key.rsplit(".", 1)
+    return parent, field_name
+
+
+def _build_context_ranges(gold_flat: dict[str, str]) -> dict[str, tuple[float, float]]:
+    """Infer sibling numeric ranges from flattened gold fields.
+
+    For anomaly detection outputs, this maps both ``answer.start_point`` and
+    ``answer.end_point`` to the interval bounded by those gold values.
+    """
+    by_parent: dict[str, dict[str, str]] = {}
+    for key in gold_flat:
+        split = _split_flat_key(key)
+        if split is None:
+            continue
+        parent, field_name = split
+        by_parent.setdefault(parent, {})[field_name] = key
+
+    ranges: dict[str, tuple[float, float]] = {}
+    for fields in by_parent.values():
+        for lower_field, upper_field in _RANGE_FIELD_PAIRS:
+            lower_key = fields.get(lower_field)
+            upper_key = fields.get(upper_field)
+            if lower_key is None or upper_key is None:
+                continue
+
+            lower = _as_float(gold_flat[lower_key])
+            upper = _as_float(gold_flat[upper_key])
+            if lower is None or upper is None:
+                continue
+
+            value_range = _normalize_range(lower, upper)
+            ranges[lower_key] = value_range
+            ranges[upper_key] = value_range
+
+    return ranges
+
+
+def _compare_value(
+    key: str,
+    gold_value: str,
+    model_value: str,
+    context_ranges: dict[str, tuple[float, float]],
+    *,
+    similarity_threshold: float,
+) -> _ValueComparison:
+    """Compare one flattened value with exact, range, and delta-1 checks."""
+    base_similarity = similarity_score(gold_value, model_value)
+    exact = gold_value == model_value
+
+    gold_num = _as_float(gold_value)
+    model_num = _as_float(model_value)
+    gold_range = _extract_numeric_range(gold_value)
+    context_range = context_ranges.get(key)
+    value_range = context_range or gold_range
+
+    numeric = (
+        gold_num is not None
+        or gold_range is not None
+        or context_range is not None
+    )
+
+    delta_1_eligible = gold_num is not None and model_num is not None
+    delta_1_match = (
+        abs(model_num - gold_num) <= 1
+        if delta_1_eligible and model_num is not None and gold_num is not None
+        else None
+    )
+
+    range_eligible = value_range is not None and model_num is not None
+    range_match = (
+        value_range[0] <= model_num <= value_range[1]
+        if range_eligible and model_num is not None and value_range is not None
+        else None
+    )
+
+    numeric_match = bool(exact or range_match or delta_1_match) if numeric else False
+    accepted = bool(exact or numeric_match)
+
+    if exact:
+        match_type = "exact"
+        similarity = 1.0
+    elif delta_1_match:
+        match_type = "partial_delta_1"
+        similarity = 1.0
+    elif range_match:
+        match_type = "partial_range"
+        similarity = 1.0
+    elif base_similarity > similarity_threshold:
+        match_type = f"partial ({base_similarity:.2f})"
+        similarity = base_similarity
+    else:
+        match_type = "mismatch"
+        similarity = base_similarity
+
+    return _ValueComparison(
+        exact=exact,
+        accepted=accepted,
+        match_type=match_type,
+        similarity=similarity,
+        numeric=numeric,
+        numeric_match=numeric_match,
+        range_eligible=range_eligible,
+        range_match=range_match,
+        delta_1_eligible=delta_1_eligible,
+        delta_1_match=delta_1_match,
+    )
+
+
 def evaluate_static_json(
     gold_answer: Any,
     model_answer: Any,
@@ -298,6 +495,7 @@ def evaluate_static_json(
     """Evaluate one structured gold answer against one model answer."""
     gold_flat = flatten_answer(gold_answer)
     model_flat = flatten_answer(model_answer)
+    context_ranges = _build_context_ranges(gold_flat)
 
     gold_keys = set(gold_flat)
     model_keys = set(model_flat)
@@ -305,32 +503,61 @@ def evaluate_static_json(
 
     details: list[KeyComparison] = []
     exact_matches = 0
+    accepted_matches = 0
+    numeric_gold_keys = 0
+    numeric_matches = 0
+    range_eligible_keys = 0
+    range_matches = 0
+    delta_1_eligible_keys = 0
+    delta_1_matches = 0
     total_similarity = 0.0
 
     for key in sorted(common_keys):
         gold_value = gold_flat[key]
         model_value = model_flat[key]
 
-        score = similarity_score(gold_value, model_value)
-        total_similarity += score
+        comparison = _compare_value(
+            key,
+            gold_value,
+            model_value,
+            context_ranges,
+            similarity_threshold=similarity_threshold,
+        )
+        total_similarity += comparison.similarity
 
-        exact = score == 1.0
-        if exact:
+        if comparison.exact:
             exact_matches += 1
-            match_type = "exact"
-        elif score > similarity_threshold:
-            match_type = f"partial ({score:.2f})"
-        else:
-            match_type = "mismatch"
+
+        if comparison.accepted:
+            accepted_matches += 1
+
+        if comparison.numeric:
+            numeric_gold_keys += 1
+            if comparison.numeric_match:
+                numeric_matches += 1
+
+        if comparison.range_eligible:
+            range_eligible_keys += 1
+            if comparison.range_match:
+                range_matches += 1
+
+        if comparison.delta_1_eligible:
+            delta_1_eligible_keys += 1
+            if comparison.delta_1_match:
+                delta_1_matches += 1
 
         details.append(
             KeyComparison(
                 key=key,
                 gold_value=gold_value,
                 model_value=model_value,
-                exact=exact,
-                match_type=match_type,
-                similarity=score,
+                exact=comparison.exact,
+                match_type=comparison.match_type,
+                similarity=comparison.similarity,
+                accepted=comparison.accepted,
+                numeric=comparison.numeric,
+                range_match=comparison.range_match,
+                delta_1_match=comparison.delta_1_match,
             )
         )
 
@@ -346,6 +573,7 @@ def evaluate_static_json(
                 exact=False,
                 match_type="missing",
                 similarity=0.0,
+                accepted=False,
             )
         )
 
@@ -358,6 +586,7 @@ def evaluate_static_json(
                 exact=False,
                 match_type="extra",
                 similarity=0.0,
+                accepted=False,
             )
         )
 
@@ -372,21 +601,42 @@ def evaluate_static_json(
         else 0.0
     )
 
+    partial_match = accepted_matches / total_gold_keys if total_gold_keys else 0.0
     partial_exact = exact_matches / total_gold_keys if total_gold_keys else 0.0
     partial_similarity = total_similarity / total_gold_keys if total_gold_keys else 0.0
+    partial_numeric = (
+        numeric_matches / numeric_gold_keys if numeric_gold_keys else 0.0
+    )
+    range_accuracy = (
+        range_matches / range_eligible_keys if range_eligible_keys else 0.0
+    )
+    delta_1_accuracy = (
+        delta_1_matches / delta_1_eligible_keys if delta_1_eligible_keys else 0.0
+    )
     strict_exact = 1.0 if gold_flat == model_flat else 0.0
 
     return StaticJsonScore(
+        partial_match_accuracy=partial_match,
         partial_exact_match_accuracy=partial_exact,
         strict_exact_match_accuracy=strict_exact,
         partial_similarity_score=partial_similarity,
+        partial_numeric_match_accuracy=partial_numeric,
+        range_match_accuracy=range_accuracy,
+        delta_1_match_accuracy=delta_1_accuracy,
         precision=precision,
         recall=recall,
         f1=f1,
         total_gold_keys=total_gold_keys,
         total_model_keys=total_model_keys,
         matched_keys=len(common_keys),
+        accepted_value_matches=accepted_matches,
         exact_value_matches=exact_matches,
+        numeric_gold_keys=numeric_gold_keys,
+        numeric_value_matches=numeric_matches,
+        range_eligible_keys=range_eligible_keys,
+        range_value_matches=range_matches,
+        delta_1_eligible_keys=delta_1_eligible_keys,
+        delta_1_value_matches=delta_1_matches,
         missing_keys=missing_keys,
         extra_keys=extra_keys,
         details=details,

--- a/src/evaluation/tests/test_static_json_scorer.py
+++ b/src/evaluation/tests/test_static_json_scorer.py
@@ -34,6 +34,10 @@ def test_parse_noisy_count_answer():
     assert parse_structured_answer("The answer is 34.") == 34
 
 
+def test_parse_fault_code_as_categorical_string():
+    assert parse_structured_answer("FC101") == "FC101"
+
+
 def test_flatten_nested_json():
     answer = {"a": {"b": 2}, "c": [3, {"d": 4}]}
 
@@ -101,6 +105,86 @@ def test_numeric_partial_similarity():
 
     assert score.strict_exact_match_accuracy == 0.0
     assert score.partial_similarity_score == 0.7
+
+
+def test_anomaly_segment_scores_exact_categorical_and_numeric_delta():
+    gold = {
+        "condition": "faulty",
+        "start_point": "240",
+        "end_point": "511",
+        "fault_type": "FC101",
+    }
+    model = {
+        "condition": "faulty",
+        "start_point": "241",
+        "end_point": "512",
+        "fault_type": "FC101",
+    }
+
+    score = evaluate_static_json(gold, model)
+    details = {item.key: item for item in score.details}
+
+    assert score.strict_exact_match_accuracy == 0.0
+    assert score.partial_exact_match_accuracy == 0.5
+    assert score.partial_match_accuracy == 1.0
+    assert score.partial_numeric_match_accuracy == 1.0
+    assert score.range_match_accuracy == 0.5
+    assert score.delta_1_match_accuracy == 1.0
+    assert details["answer.condition"].match_type == "exact"
+    assert details["answer.fault_type"].match_type == "exact"
+    assert details["answer.start_point"].match_type == "partial_delta_1"
+    assert details["answer.start_point"].range_match is True
+    assert details["answer.start_point"].delta_1_match is True
+    assert details["answer.end_point"].match_type == "partial_delta_1"
+    assert details["answer.end_point"].range_match is False
+    assert details["answer.end_point"].delta_1_match is True
+
+
+def test_anomaly_segment_scores_numeric_range_match():
+    gold = {
+        "condition": "faulty",
+        "start_point": "240",
+        "end_point": "511",
+        "fault_type": "FC101",
+    }
+    model = {
+        "condition": "faulty",
+        "start_point": "300",
+        "end_point": "500",
+        "fault_type": "FC101",
+    }
+
+    score = evaluate_static_json(gold, model)
+    details = {item.key: item for item in score.details}
+
+    assert score.strict_exact_match_accuracy == 0.0
+    assert score.partial_exact_match_accuracy == 0.5
+    assert score.partial_match_accuracy == 1.0
+    assert score.range_match_accuracy == 1.0
+    assert score.delta_1_match_accuracy == 0.0
+    assert details["answer.start_point"].match_type == "partial_range"
+    assert details["answer.end_point"].match_type == "partial_range"
+
+
+def test_count_only_delta_one_is_numeric_partial_match():
+    score = evaluate_static_json("34", "35")
+
+    assert score.strict_exact_match_accuracy == 0.0
+    assert score.partial_exact_match_accuracy == 0.0
+    assert score.partial_match_accuracy == 1.0
+    assert score.partial_numeric_match_accuracy == 1.0
+    assert score.delta_1_match_accuracy == 1.0
+    assert score.details[0].match_type == "partial_delta_1"
+
+
+def test_numeric_answer_can_match_explicit_ground_truth_range():
+    score = evaluate_static_json({"count": "10-12"}, {"count": 11})
+
+    assert score.strict_exact_match_accuracy == 0.0
+    assert score.partial_match_accuracy == 1.0
+    assert score.partial_numeric_match_accuracy == 1.0
+    assert score.range_match_accuracy == 1.0
+    assert score.details[0].match_type == "partial_range"
 
 
 def test_count_only_exact_match():


### PR DESCRIPTION
This PR extends the evaluator for structured JSON-style scenario outputs.

Changes include:
- Parse structured answers from noisy model outputs, including markdown JSON blocks.
- Score JSON objects, Python-style dicts/lists, and count-only answers.
- Compare categorical values using exact match.
- Compare numeric/timestamp values using exact match, range containment, and delta +/- 1 matching.
- Add aggregate reporting for partial match, strict exact match, range match, delta match, and similarity metrics.
- Add tests for structured JSON scoring and operational metric aggregation.

