### PR TITLE
Fix TokenRouter GPT-5 OpenCode tool calls

### DIFF
--- a/src/agent/opencode_agent/runner.py
+++ b/src/agent/opencode_agent/runner.py
@@ -60,6 +60,11 @@ class OpenCodeTrajectory(Trajectory):
     stderr: str = ""
 
 
+def _needs_reasoning_effort_none(provider_id: str, model_name: str) -> bool:
+    """Whether OpenCode should disable reasoning_effort for this router model."""
+    return provider_id == "tokenrouter" and model_name.startswith("openai/gpt-5")
+
+
 def _build_mcp_config(
     server_paths: dict[str, Path | str],
     *,
@@ -132,6 +137,11 @@ def _resolve_opencode_model_and_provider(
         if provider_id == "tokenrouter" and model_name.startswith("anthropic/")
         else "@ai-sdk/openai-compatible"
     )
+    model_config: dict[str, Any] = {"name": model_name}
+    if _needs_reasoning_effort_none(provider_id, model_name):
+        # TokenRouter rejects function tools for OpenAI GPT-5 models on
+        # chat/completions unless reasoning_effort is explicitly disabled.
+        model_config["options"] = {"reasoningEffort": "none"}
     provider = {
         provider_id: {
             "npm": provider_npm,
@@ -141,9 +151,7 @@ def _resolve_opencode_model_and_provider(
                 "apiKey": "{env:ASSETOPSBENCH_OPENCODE_API_KEY}",
             },
             "models": {
-                model_name: {
-                    "name": model_name,
-                }
+                model_name: model_config,
             },
         }
     }
@@ -253,6 +261,35 @@ def _json_events(stdout: str) -> tuple[list[dict[str, Any]], list[str]]:
         else:
             plain_lines.append(line)
     return events, plain_lines
+
+
+def _opencode_error_message(events: list[dict[str, Any]]) -> str | None:
+    """Return a concise message for fatal OpenCode error events, if present."""
+    for event in events:
+        if event.get("type") != "error" and not event.get("error"):
+            continue
+
+        error = event.get("error")
+        if isinstance(error, dict):
+            data = error.get("data") if isinstance(error.get("data"), dict) else {}
+            message = (
+                data.get("message")
+                or error.get("message")
+                or data.get("responseBody")
+                or json.dumps(error, default=str)
+            )
+            name = error.get("name")
+            status = data.get("statusCode")
+            prefix = "OpenCode error"
+            if name:
+                prefix += f" {name}"
+            if status:
+                prefix += f" ({status})"
+            return f"{prefix}: {message}"
+
+        return f"OpenCode error event: {json.dumps(event, default=str)}"
+
+    return None
 
 
 def _candidate_part(event: dict[str, Any]) -> dict[str, Any] | None:
@@ -699,6 +736,9 @@ class OpenCodeAgentRunner(AgentRunner):
 
             duration_ms = (time.perf_counter() - run_started) * 1000
             events, plain_lines = _json_events(stdout)
+            error_message = _opencode_error_message(events)
+            if error_message:
+                raise RuntimeError(error_message)
             answer, trajectory = _build_trajectory_from_events(
                 events,
                 plain_lines,

--- a/src/agent/opencode_agent/tests/test_runner.py
+++ b/src/agent/opencode_agent/tests/test_runner.py
@@ -13,6 +13,8 @@ from agent.opencode_agent.runner import (
     _build_permissions,
     _build_trajectory_from_events,
     _json_events,
+    _needs_reasoning_effort_none,
+    _opencode_error_message,
     _resolve_run_dir,
     _resolve_opencode_model_and_provider,
 )
@@ -149,6 +151,27 @@ def test_resolve_tokenrouter_anthropic_model(monkeypatch):
     )  # pragma: allowlist secret
 
 
+def test_tokenrouter_gpt5_models_need_reasoning_effort_none():
+    assert _needs_reasoning_effort_none("tokenrouter", "openai/gpt-5.5")
+    assert _needs_reasoning_effort_none("tokenrouter", "openai/gpt-5.6-sol")
+    assert not _needs_reasoning_effort_none("tokenrouter", "MiniMax-M3")
+    assert not _needs_reasoning_effort_none("litellm-proxy", "openai/gpt-5.6-sol")
+
+
+def test_resolve_tokenrouter_gpt5_disables_reasoning_effort(monkeypatch):
+    monkeypatch.setenv("TOKENROUTER_BASE_URL", "https://router.example/v1")
+    monkeypatch.setenv("TOKENROUTER_API_KEY", "tr-test")
+    for model_id in ("tokenrouter/openai/gpt-5.5", "tokenrouter/openai/gpt-5.6-sol"):
+        model, provider, env = _resolve_opencode_model_and_provider(model_id)
+        model_name = model_id.removeprefix("tokenrouter/")
+        assert model == model_id
+        model_config = provider["tokenrouter"]["models"][model_name]
+        assert model_config["options"] == {"reasoningEffort": "none"}
+        assert (
+            env["ASSETOPSBENCH_OPENCODE_API_KEY"] == "tr-test"
+        )  # pragma: allowlist secret
+
+
 def test_build_opencode_config_includes_agent_and_mcp():
     config, env, opencode_model = _build_opencode_config(
         model="opencode/gpt-5",
@@ -168,6 +191,29 @@ def test_json_events_parses_ndjson_and_plain_lines():
     events, plain = _json_events('{"type":"a"}\nnot-json\n{"type":"b"}\n')
     assert [event["type"] for event in events] == ["a", "b"]
     assert plain == ["not-json"]
+
+
+def test_opencode_error_message_extracts_api_error():
+    message = _opencode_error_message(
+        [
+            {
+                "type": "error",
+                "error": {
+                    "name": "APIError",
+                    "data": {
+                        "statusCode": 400,
+                        "message": "Function tools are not supported.",
+                    },
+                },
+            }
+        ]
+    )
+
+    assert message == "OpenCode error APIError (400): Function tools are not supported."
+
+
+def test_opencode_error_message_ignores_null_error_field():
+    assert _opencode_error_message([{"type": "step_finish", "error": None}]) is None
 
 
 def test_build_trajectory_from_text_and_tool_parts():


### PR DESCRIPTION
## Summary
- disable OpenCode reasoning_effort for TokenRouter-hosted OpenAI GPT-5 models so function/MCP tools work on chat/completions
- surface OpenCode error events as RuntimeError instead of returning an empty trajectory/answer
- add coverage for tokenrouter/openai/gpt-5.5 and tokenrouter/openai/gpt-5.6-sol

Closes #443

## Verification
- uv run pytest src/agent/opencode_agent/tests/test_runner.py -q
- uv run opencode-agent --model-id tokenrouter/openai/gpt-5.6-sol --show-trajectory --max-steps 3 "hello"
- uv run opencode-agent --model-id tokenrouter/openai/gpt-5.5 --show-trajectory "hello"