### PR TITLE
Limit IoT MCP server to registry tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ AssetOpsBench is a **unified framework for developing, orchestrating, and evalua
 
 | MCP Servers | Important tools |
 |---|---|
-| **IoT** | `get_sites`, `get_history`, `get_assets`, `get_sensors` |
+| **IoT** | `asset_ids`, `assets` |
 | **FMSR** | `get_failure_modes`, `generate_failure_modes`, `add_failure_modes`, `generate_failure_mode_sensor_mapping` |
 | **TSFM** | `forecasting`, `timeseries_anomaly_detection` |
 | **WO** | `get_work_order_distribution`, `predict_next_work_order`, ... |
@@ -110,7 +110,7 @@ The `src/` directory contains MCP servers and a plan-execute runner built on the
 
 | Domain | Example Task |
 |---|---|
-| **IoT** | "List all sensors of Chiller 6 in MAIN site" |
+| **IoT** | "List all assets in MAIN site" |
 | **FMSR** | "List known failure modes for asset class pump" |
 | **TSFM** | "Forecast Chiller 9 Condenser Water Flow for the week of 2020-04-27" |
 | **WO** | "Generate a work order for Chiller 6 anomaly detection" |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ AssetOpsBench is a **unified framework for developing, orchestrating, and evalua
 
 | MCP Servers | Important tools |
 |---|---|
-| **IoT** | `asset_ids`, `assets` |
+| **IoT** | `sites`, `asset_ids`, `assets` |
 | **FMSR** | `get_failure_modes`, `generate_failure_modes`, `add_failure_modes`, `generate_failure_mode_sensor_mapping` |
 | **TSFM** | `forecasting`, `timeseries_anomaly_detection` |
 | **WO** | `get_work_order_distribution`, `predict_next_work_order`, ... |

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -15,12 +15,12 @@ Six FastMCP servers expose the AssetOpsBench domain logic. Each is a standalone 
 
 The IoT server reads from **two** databases: telemetry readings (`IOT_DBNAME`, default `iot`) and an
 asset **registry** (`ASSET_DBNAME`, default `asset`, loaded from `asset_profile_sample.json`). The
-two answer different questions: `assets()`/`sensors()` reflect TELEMETRY — what actually streams (the
-**measured** set); `get_asset()`/`asset_sensors()`/`registry_assets()` reflect the REGISTRY — the
-asset nameplate and the **installed** sensor inventory (by name). Comparing `asset_sensors()` against
-`sensors()` surfaces sensors that are installed but not streaming. The registry also reconciles ids
-across systems (Maximo `assetnum`, telemetry `iot_asset_id`, work-order `wo_assetnum`), so an asset
-can be looked up by any of its ids.
+two answer different questions: `asset_ids()` lists bare ids to pass to telemetry tools; `sensors()`
+reflects TELEMETRY — what actually streams (the **measured** set); `assets()`/`get_asset()`/
+`asset_sensors()`/`registry_assets()` reflect the REGISTRY — the asset nameplate and the **installed**
+sensor inventory (by name). Comparing `asset_sensors()` against `sensors()` surfaces sensors that are
+installed but not streaming. The registry also reconciles ids across systems (Maximo `assetnum`,
+telemetry `iot_asset_id`, work-order `wo_assetnum`), so an asset can be looked up by any of its ids.
 
 **Path:** `src/servers/iot/main.py`
 **Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `IOT_DBNAME`, `ASSET_DBNAME`)
@@ -38,7 +38,8 @@ Synthetic motor vibration data (`asset_id: Motor_01`, from `motor_01.json`) ship
 | Tool              | Arguments                                  | Description                                                                                                  |
 | ----------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | `sites`           | —                                          | List all sites, discovered dynamically from the asset registry (`siteid`)                                    |
-| `assets`          | `site_name`                                | List asset ids registered at a site (telemetry id where present, else `assetnum`)                            |
+| `asset_ids`       | `site_name`                                | List bare asset ids registered at a site (telemetry id where present, else `assetnum`)                       |
+| `assets`          | `site_name`, `assettype?`                  | List assets with metadata (assettype, description, vintage, installed sensor count), optionally filtered by assettype |
 | `sensors`         | `site_name`, `asset_id`                    | List **measured** sensor names for an asset (union of keys across its telemetry docs)                        |
 | `history`         | `site_name`, `asset_id`, `start`, `final?` | Fetch historical sensor readings for a time range (ISO 8601 timestamps)                                      |
 | `get_asset`       | `site_name`, `asset_id`                    | Registry/nameplate detail for one asset (description, assettype, status, location, vintage, installed count) |

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -4,47 +4,37 @@ Six FastMCP servers expose the AssetOpsBench domain logic. Each is a standalone 
 
 ## Contents
 
-- [iot — IoT Sensor Data](#iot--iot-sensor-data)
+- [iot — IoT Asset Registry](#iot--iot-asset-registry)
 - [utilities — Utilities](#utilities--utilities)
 - [fmsr — Failure Mode and Sensor Relations](#fmsr--failure-mode-and-sensor-relations)
 - [wo — Work Order](#wo--work-order)
 - [tsfm — Time Series Foundation Model](#tsfm--time-series-foundation-model)
 - [vibration — Vibration Diagnostics](#vibration--vibration-diagnostics)
 
-## iot — IoT Sensor Data
+## iot — IoT Asset Registry
 
-The IoT server reads from **two** databases: telemetry readings (`IOT_DBNAME`, default `iot`) and an
-asset **registry** (`ASSET_DBNAME`, default `asset`, loaded from `asset_profile_sample.json`). The
-two answer different questions: `asset_ids()` lists bare ids to pass to telemetry tools; `sensors()`
-reflects TELEMETRY — what actually streams (the **measured** set); `assets()`/`get_asset()`/
-`asset_sensors()`/`registry_assets()` reflect the REGISTRY — the asset nameplate and the **installed**
-sensor inventory (by name). Comparing `asset_sensors()` against `sensors()` surfaces sensors that are
-installed but not streaming. The registry also reconciles ids across systems (Maximo `assetnum`,
-telemetry `iot_asset_id`, work-order `wo_assetnum`), so an asset can be looked up by any of its ids.
+The IoT server reads from the asset **registry** (`ASSET_DBNAME`, default `asset`, loaded from
+`asset_profile_sample.json`). It exposes only two tools while the IoT tool surface is being rebuilt:
+`asset_ids()` for bare `assetnum` values, and `assets()` for registry metadata with optional
+`assettype` filtering.
 
 **Path:** `src/servers/iot/main.py`
-**Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `IOT_DBNAME`, `ASSET_DBNAME`)
+**Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `ASSET_DBNAME`)
 
-**Sample assets shipped in the `iot` database** (loaded by `src/couchdb/couchdb_setup.sh`):
+**Sample asset profiles shipped in the `asset` database** (loaded by `src/couchdb/init_data.py`):
 
-| `asset_id`  | Asset class      | Source file                                       |
-| ----------- | ---------------- | ------------------------------------------------- |
-| `Chiller 6` | Chiller          | `src/couchdb/sample_data/iot/chiller_6.json`         |
-| `mp_1`      | Metro pump       | `src/couchdb/sample_data/iot/metro_pump_1.json`      |
-| `hyd_1`     | Hydraulic pump   | `src/couchdb/sample_data/iot/hydraulic_pump_1.json`  |
+| `assetnum`  | Asset class      |
+| ----------- | ---------------- |
+| `Chiller 6` | Chiller          |
+| `mp_1`      | Compressor       |
+| `hyd_1`     | Hydraulic pump   |
 
-Synthetic motor vibration data (`asset_id: Motor_01`, from `motor_01.json`) ships in a separate `vibration` database for the vibration MCP server.
+Source file: `src/couchdb/scenarios_data/shared/iot/asset_profile_sample.json`.
 
 | Tool              | Arguments                                  | Description                                                                                                  |
 | ----------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
-| `sites`           | —                                          | List all sites, discovered dynamically from the asset registry (`siteid`)                                    |
-| `asset_ids`       | `site_name`                                | List bare asset ids registered at a site (telemetry id where present, else `assetnum`)                       |
+| `asset_ids`       | `site_name`                                | List bare `assetnum` values registered at a site                                                            |
 | `assets`          | `site_name`, `assettype?`                  | List assets with metadata (assettype, description, vintage, installed sensor count), optionally filtered by assettype |
-| `sensors`         | `site_name`, `asset_id`                    | List **measured** sensor names for an asset (union of keys across its telemetry docs)                        |
-| `history`         | `site_name`, `asset_id`, `start`, `final?` | Fetch historical sensor readings for a time range (ISO 8601 timestamps)                                      |
-| `get_asset`       | `site_name`, `asset_id`                    | Registry/nameplate detail for one asset (description, assettype, status, location, vintage, installed count) |
-| `asset_sensors`   | `site_name`, `asset_id`                    | List the **installed** sensors for an asset, by name (registry inventory)                                    |
-| `registry_assets` | `site_name`, `assettype?`                  | List registry assets with metadata (assettype, vintage, sensor count), optionally filtered by assettype     |
 
 ## utilities — Utilities
 

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -14,9 +14,9 @@ Six FastMCP servers expose the AssetOpsBench domain logic. Each is a standalone 
 ## iot — IoT Asset Registry
 
 The IoT server reads from the asset **registry** (`ASSET_DBNAME`, default `asset`, loaded from
-`asset_profile_sample.json`). It exposes only two tools while the IoT tool surface is being rebuilt:
-`asset_ids()` for bare `assetnum` values, and `assets()` for registry metadata with optional
-`assettype` filtering.
+`asset_profile_sample.json`). It exposes registry discovery tools while the broader IoT tool surface
+is being rebuilt: `sites()` for site names, `asset_ids()` for bare `assetnum` values, and `assets()`
+for registry metadata with optional `assettype` filtering.
 
 **Path:** `src/servers/iot/main.py`
 **Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `ASSET_DBNAME`)
@@ -33,6 +33,7 @@ Source file: `src/couchdb/scenarios_data/shared/iot/asset_profile_sample.json`.
 
 | Tool              | Arguments                                  | Description                                                                                                  |
 | ----------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `sites`           | -                                          | List known site names from the asset registry, with a default fallback                                       |
 | `asset_ids`       | `site_name`                                | List bare `assetnum` values registered at a site                                                            |
 | `assets`          | `site_name`, `assettype?`                  | List assets with metadata (assettype, description, vintage, installed sensor count), optionally filtered by assettype |
 

--- a/docs/opencode-agent.md
+++ b/docs/opencode-agent.md
@@ -103,7 +103,7 @@ uv run opencode-agent --show-trajectory \
 ```
 
 In the `--show-trajectory` output, look for domain tool calls such as
-`iot_asset_ids`, `iot_assets`, or `wo_list_workorders`. That confirms
+`iot_sites`, `iot_asset_ids`, `iot_assets`, or `wo_list_workorders`. That confirms
 OpenCode discovered and called the AssetOpsBench MCP tools.
 
 > **Quiet runs.** `opencode-agent` runs OpenCode as a subprocess. During long

--- a/docs/opencode-agent.md
+++ b/docs/opencode-agent.md
@@ -103,7 +103,7 @@ uv run opencode-agent --show-trajectory \
 ```
 
 In the `--show-trajectory` output, look for domain tool calls such as
-`iot_sites`, `iot_registry_assets`, or `wo_list_workorders`. That confirms
+`iot_asset_ids`, `iot_assets`, or `wo_list_workorders`. That confirms
 OpenCode discovered and called the AssetOpsBench MCP tools.
 
 > **Quiet runs.** `opencode-agent` runs OpenCode as a subprocess. During long

--- a/docs/tool_universe.md
+++ b/docs/tool_universe.md
@@ -6,15 +6,15 @@ from mcphub import ToolUniverse
 tu = ToolUniverse()                          # 1. init
 tu.load_tools()                              # 2. load (connect + discover)
 tu.run({                                     # 3. run
-    "name": "iot.sensors",
-    "arguments": {"site_name": "MAIN", "asset_id": "Chiller 6"},
+    "name": "iot.asset_ids",
+    "arguments": {"site_name": "MAIN"},
 })
 tu.close()
 ```
 
 `load_tools(servers=[...])` limits to specific servers. Tools are namespaced
-`<server>.<tool>`; a bare name (e.g. `sensors`) also works when unambiguous.
-A shorthand `tu.run("iot.sensors", {...})` is accepted too.
+`<server>.<tool>`; a bare name (e.g. `asset_ids`) also works when unambiguous.
+A shorthand `tu.run("iot.asset_ids", {...})` is accepted too.
 
 ## Discovery
 
@@ -22,21 +22,13 @@ A shorthand `tu.run("iot.sensors", {...})` is accepted too.
 tu.find_tools("failure mode")     # keyword search over loaded tools
 tu.list_tools()                   # all loaded tool + workflow names
 tu.list_tools("fmsr")             # tool names for one server
-tu.tool_specification("iot.sensors")
+tu.tool_specification("iot.asset_ids")
 ```
 
 ## Workflows
 
-Composed workflows run through the **same `run` entrypoint**:
-
-```python
-tu.run({"name": "chiller_triage", "arguments": {"asset_id": "Chiller 6"}})
-```
-
 Add one by writing `fn(tu, **arguments)` in `workflows.py` and listing its name
-in `REGISTERED` (or `tu.register_workflow("name", fn)` at runtime). Built in:
-`chiller_triage` (sensors → failure modes → mapping → work order) and
-`sensor_inventory_gap` (installed vs measured sensors).
+in `REGISTERED` (or `tu.register_workflow("name", fn)` at runtime).
 
 ## Run
 

--- a/examples/quickstart_tooluniverse.py
+++ b/examples/quickstart_tooluniverse.py
@@ -25,15 +25,14 @@ def main():
              [s["name"] for s in tu.find_tools("failure mode")])
 
         # 3. run a single tool (ToolUniverse dict form)
-        show("iot.sensors", tu.run({
-            "name": "iot.sensors",
-            "arguments": {"site_name": "MAIN", "asset_id": "Chiller 6"},
+        show("iot.asset_ids", tu.run({
+            "name": "iot.asset_ids",
+            "arguments": {"site_name": "MAIN"},
         }))
 
-        # A workflow runs through the same entrypoint
-        show("chiller_triage", tu.run({
-            "name": "chiller_triage",
-            "arguments": {"asset_id": "Chiller 6", "raise_work_order": False},
+        show("iot.assets", tu.run({
+            "name": "iot.assets",
+            "arguments": {"site_name": "MAIN", "assettype": "CHILLER"},
         }))
     finally:
         tu.close()

--- a/src/couchdb/scenarios_data/shared/iot/asset_profile_sample.json
+++ b/src/couchdb/scenarios_data/shared/iot/asset_profile_sample.json
@@ -1,10 +1,6 @@
 [
   {
-    "_id": "asset:CHILLER6",
-    "doctype": "asset",
-    "assetnum": "CHILLER6",
-    "iot_asset_id": "Chiller 6",
-    "wo_assetnum": "CHILLER6",
+    "assetnum": "Chiller 6",
     "description": "Chiller 6 (chilled-water plant)",
     "siteid": "MAIN",
     "orgid": "RIVPLANT",
@@ -35,11 +31,7 @@
     ]
   },
   {
-    "_id": "asset:mp_1",
-    "doctype": "asset",
     "assetnum": "mp_1",
-    "iot_asset_id": "mp_1",
-    "wo_assetnum": null,
     "description": "Compressor / pneumatic system",
     "siteid": "MAIN",
     "orgid": "RIVPLANT",
@@ -73,11 +65,7 @@
     ]
   },
   {
-    "_id": "asset:hyd_1",
-    "doctype": "asset",
     "assetnum": "hyd_1",
-    "iot_asset_id": "hyd_1",
-    "wo_assetnum": null,
     "description": "Hydraulic pump condition-monitoring rig",
     "siteid": "MAIN",
     "orgid": "RIVPLANT",
@@ -114,11 +102,7 @@
     ]
   },
   {
-    "_id": "asset:Motor_01",
-    "doctype": "asset",
     "assetnum": "Motor_01",
-    "iot_asset_id": "Motor_01",
-    "wo_assetnum": null,
     "description": "Induction motor (vibration-monitored)",
     "siteid": "MAIN",
     "orgid": "RIVPLANT",
@@ -138,11 +122,7 @@
     ]
   },
   {
-    "_id": "asset:PUMP3",
-    "doctype": "asset",
     "assetnum": "PUMP3",
-    "iot_asset_id": null,
-    "wo_assetnum": "PUMP3",
     "description": "Pump 3",
     "siteid": "MAIN",
     "orgid": "RIVPLANT",
@@ -160,11 +140,7 @@
     "sensors": []
   },
   {
-    "_id": "asset:AHU2",
-    "doctype": "asset",
     "assetnum": "AHU2",
-    "iot_asset_id": null,
-    "wo_assetnum": "AHU2",
     "description": "Air handling unit 2",
     "siteid": "NORTH",
     "orgid": "RIVPLANT",

--- a/src/mcphub/__init__.py
+++ b/src/mcphub/__init__.py
@@ -11,8 +11,8 @@ dependency on any external ``tooluniverse`` package.
     tu = ToolUniverse()                                   # 1. init
     tu.load_tools()                                       # 2. load (connect + discover)
     tu.run({                                              # 3. run
-        "name": "iot.sensors",
-        "arguments": {"site_name": "MAIN", "asset_id": "Chiller 6"},
+        "name": "iot.asset_ids",
+        "arguments": {"site_name": "MAIN"},
     })
 
 Tools are namespaced ``<server>.<tool>``; a bare tool name also works when it is
@@ -202,8 +202,8 @@ class ToolUniverse:
     def run(self, query, arguments: Optional[dict] = None) -> Any:
         """Execute a tool or workflow.
 
-        ToolUniverse form:  run({"name": "iot.sensors", "arguments": {...}})
-        Shorthand:          run("iot.sensors", {...})
+        ToolUniverse form:  run({"name": "iot.asset_ids", "arguments": {...}})
+        Shorthand:          run("iot.asset_ids", {...})
         """
         if isinstance(query, dict):
             name = query["name"]

--- a/src/mcphub/tests/test_workflows.py
+++ b/src/mcphub/tests/test_workflows.py
@@ -8,10 +8,10 @@ def test_iot_sensor_workflows_are_not_registered():
 
 
 def test_chiller_triage_is_disabled():
-    with pytest.raises(RuntimeError, match="asset_ids\\(\\) and assets\\(\\)"):
+    with pytest.raises(RuntimeError, match="does not expose sensor tools"):
         workflows.chiller_triage(object(), asset_id="Pump-1")
 
 
 def test_sensor_inventory_gap_is_disabled():
-    with pytest.raises(RuntimeError, match="asset_ids\\(\\) and assets\\(\\)"):
+    with pytest.raises(RuntimeError, match="does not expose sensor tools"):
         workflows.sensor_inventory_gap(object(), asset_id="Pump-1")

--- a/src/mcphub/tests/test_workflows.py
+++ b/src/mcphub/tests/test_workflows.py
@@ -1,38 +1,17 @@
-from mcphub.workflows import chiller_triage
+import pytest
+
+from mcphub import workflows
 
 
-class FakeToolUniverse:
-    def __init__(self):
-        self.calls = []
-
-    def run(self, name, arguments):
-        self.calls.append((name, arguments))
-        if name == "iot.sensors":
-            return {"sensors": ["Pressure sensor", "Vibration sensor"]}
-        if name == "fmsr.get_failure_modes":
-            return {
-                "asset_class": "pump",
-                "failure_modes": ["seal leakage", "impeller wear"],
-            }
-        if name == "fmsr.generate_failure_mode_sensor_mapping":
-            return {"metadata": arguments}
-        raise AssertionError(f"unexpected tool call: {name}")
+def test_iot_sensor_workflows_are_not_registered():
+    assert workflows.REGISTERED == []
 
 
-def test_chiller_triage_passes_lists_to_mapping_tool():
-    tu = FakeToolUniverse()
+def test_chiller_triage_is_disabled():
+    with pytest.raises(RuntimeError, match="asset_ids\\(\\) and assets\\(\\)"):
+        workflows.chiller_triage(object(), asset_id="Pump-1")
 
-    result = chiller_triage(tu, asset_id="Pump-1", raise_work_order=False)
 
-    mapping_call = [
-        arguments
-        for name, arguments in tu.calls
-        if name == "fmsr.generate_failure_mode_sensor_mapping"
-    ][0]
-    assert mapping_call == {
-        "asset_class": "pump",
-        "failure_modes": ["seal leakage", "impeller wear"],
-        "sensors": ["Pressure sensor", "Vibration sensor"],
-    }
-    assert result["failure_modes_result"]["asset_class"] == "pump"
-    assert result["failure_modes"] == ["seal leakage", "impeller wear"]
+def test_sensor_inventory_gap_is_disabled():
+    with pytest.raises(RuntimeError, match="asset_ids\\(\\) and assets\\(\\)"):
+        workflows.sensor_inventory_gap(object(), asset_id="Pump-1")

--- a/src/mcphub/workflows.py
+++ b/src/mcphub/workflows.py
@@ -2,9 +2,7 @@
 Composed workflows — plain functions that chain tool calls.
 
 Each takes a ``ToolUniverse`` instance and returns a dict. Names listed in
-``REGISTERED`` are auto-registered so they run through the same entrypoint::
-
-    tu.run({"name": "chiller_triage", "arguments": {"asset_id": "Chiller 6"}})
+``REGISTERED`` are auto-registered so they run through the same entrypoint.
 
 To add one: write a function ``fn(tu, **arguments)`` and add its name to
 ``REGISTERED``.
@@ -12,7 +10,9 @@ To add one: write a function ``fn(tu, **arguments)`` and add its name to
 
 import re
 
-REGISTERED = ["chiller_triage", "sensor_inventory_gap"]
+# IoT sensor workflows are temporarily not auto-registered while the IoT MCP
+# server exposes only asset_ids() and assets().
+REGISTERED = []
 
 
 def _asset_class_from_asset_id(asset_id):
@@ -22,53 +22,19 @@ def _asset_class_from_asset_id(asset_id):
 
 
 def chiller_triage(tu, asset_id, site="MAIN", raise_work_order=True, priority="2"):
-    """Sensors -> failure modes -> mode/sensor mapping -> (optional) work order."""
-    asset_class = _asset_class_from_asset_id(asset_id)
-    sensors = _names(tu.run("iot.sensors", {"site_name": site, "asset_id": asset_id}))
-    failure_modes_result = tu.run("fmsr.get_failure_modes", {"asset_class": asset_class})
-    failure_modes = (
-        failure_modes_result.get("failure_modes", [])
-        if isinstance(failure_modes_result, dict)
-        else failure_modes_result
+    """Disabled while the IoT MCP server exposes only asset_ids() and assets()."""
+    raise RuntimeError(
+        "chiller_triage is disabled while the IoT MCP server exposes only "
+        "asset_ids() and assets()."
     )
-    mapping = tu.run("fmsr.generate_failure_mode_sensor_mapping", {
-        "asset_class": asset_class,
-        "failure_modes": failure_modes,
-        "sensors": sensors,
-    })
-
-    out = {
-        "asset_id": asset_id,
-        "asset_class": asset_class,
-        "site_name": site,
-        "sensors": sensors,
-        "failure_modes_result": failure_modes_result,
-        "failure_modes": failure_modes,
-        "failure_mode_sensor_mapping": mapping,
-    }
-    if raise_work_order:
-        out["work_order"] = tu.run("wo.generate_work_order", {
-            "description": f"Investigate potential failure modes on {asset_id}",
-            "asset_num": asset_id,
-            "site_id": site,
-            "priority": priority,
-            "aob_source": "mcphub:chiller_triage",
-        })
-    return out
 
 
 def sensor_inventory_gap(tu, asset_id, site="MAIN"):
-    """Installed (registry) vs measured (telemetry) sensors for an asset."""
-    installed = _names(tu.run("iot.asset_sensors",
-                              {"site_name": site, "asset_id": asset_id}))
-    measured = _names(tu.run("iot.sensors",
-                             {"site_name": site, "asset_id": asset_id}))
-    return {
-        "asset_id": asset_id,
-        "site_name": site,
-        "installed_not_streaming": sorted(set(installed) - set(measured)),
-        "streaming_not_in_registry": sorted(set(measured) - set(installed)),
-    }
+    """Disabled while the IoT MCP server exposes only asset_ids() and assets()."""
+    raise RuntimeError(
+        "sensor_inventory_gap is disabled while the IoT MCP server exposes only "
+        "asset_ids() and assets()."
+    )
 
 
 def _names(value):

--- a/src/mcphub/workflows.py
+++ b/src/mcphub/workflows.py
@@ -11,7 +11,7 @@ To add one: write a function ``fn(tu, **arguments)`` and add its name to
 import re
 
 # IoT sensor workflows are temporarily not auto-registered while the IoT MCP
-# server exposes only asset_ids() and assets().
+# server exposes only registry discovery tools.
 REGISTERED = []
 
 
@@ -22,18 +22,18 @@ def _asset_class_from_asset_id(asset_id):
 
 
 def chiller_triage(tu, asset_id, site="MAIN", raise_work_order=True, priority="2"):
-    """Disabled while the IoT MCP server exposes only asset_ids() and assets()."""
+    """Disabled while the IoT MCP server does not expose sensor tools."""
     raise RuntimeError(
-        "chiller_triage is disabled while the IoT MCP server exposes only "
-        "asset_ids() and assets()."
+        "chiller_triage is disabled while the IoT MCP server does not expose "
+        "sensor tools."
     )
 
 
 def sensor_inventory_gap(tu, asset_id, site="MAIN"):
-    """Disabled while the IoT MCP server exposes only asset_ids() and assets()."""
+    """Disabled while the IoT MCP server does not expose sensor tools."""
     raise RuntimeError(
-        "sensor_inventory_gap is disabled while the IoT MCP server exposes only "
-        "asset_ids() and assets()."
+        "sensor_inventory_gap is disabled while the IoT MCP server does not expose "
+        "sensor tools."
     )
 
 

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -1,46 +1,26 @@
-import os
 import logging
-from datetime import datetime
-from functools import lru_cache
+import os
 from typing import Any, Dict, List, Optional, Union
-from mcp.server.fastmcp import FastMCP
-from pydantic import BaseModel
+
 import couchdb3
 from dotenv import load_dotenv
+from mcp.server.fastmcp import FastMCP
+from pydantic import BaseModel
 
 load_dotenv()
 
-# Setup logging — default WARNING so stderr stays quiet when used as MCP server;
-# set LOG_LEVEL=INFO (or DEBUG) in the environment to see verbose output.
+# Setup logging; default WARNING keeps stderr quiet when used as an MCP server.
 _log_level = getattr(
     logging, os.environ.get("LOG_LEVEL", "WARNING").upper(), logging.WARNING
 )
 logging.basicConfig(level=_log_level)
 logger = logging.getLogger("iot-mcp-server")
 
-# Configuration from environment
 COUCHDB_URL = os.environ.get("COUCHDB_URL")
-COUCHDB_DBNAME = os.environ.get("IOT_DBNAME")
 COUCHDB_USERNAME = os.environ.get("COUCHDB_USERNAME")
 COUCHDB_PASSWORD = os.environ.get("COUCHDB_PASSWORD")
-
-# Initialize CouchDB
-try:
-    db = couchdb3.Database(
-        COUCHDB_DBNAME,
-        url=COUCHDB_URL,
-        user=COUCHDB_USERNAME,
-        password=COUCHDB_PASSWORD,
-    )
-    logger.info(f"Connected to CouchDB: {COUCHDB_DBNAME}")
-except Exception as e:
-    logger.error(f"Failed to connect to CouchDB: {e}")
-    db = None
-
-# The asset registry is loaded as its own collection (manifest key "asset"), and the loader makes
-# database name == collection key — so it lives in the "asset" database, NOT in IOT_DBNAME. Open a
-# second handle for it. Telemetry (assets/sensors/history) keeps using `db` (the iot readings DB).
 ASSET_DBNAME = os.environ.get("ASSET_DBNAME", "asset")
+
 try:
     asset_db = couchdb3.Database(
         ASSET_DBNAME,
@@ -56,12 +36,8 @@ except Exception as e:
 mcp = FastMCP(
     "iot",
     instructions=(
-        "IoT sensor data + asset registry. Browse sites, assets, and sensors, read the asset "
-        "nameplate (registry), see which installed sensors are actually measured (streaming), and "
-        "query historical readings from CouchDB. NOTE: asset_ids() lists IDs to pass to telemetry "
-        "tools; sensors() reflects TELEMETRY (what streams = measured); assets()/get_asset()/"
-        "asset_sensors()/registry_assets() reflect the REGISTRY (what is installed, by name). "
-        "Compare the two to find installed-but-not-streaming sensors."
+        "IoT asset registry tools. This server only exposes asset_ids(), for bare assetnum "
+        "values, and assets(), for registry metadata with optional assettype filtering."
     ),
 )
 
@@ -72,54 +48,10 @@ class ErrorResult(BaseModel):
     error: str
 
 
-class SitesResult(BaseModel):
-    sites: List[str]
-
-
 class AssetsResult(BaseModel):
     site_name: str
     total_assets: int
     assets: List[str]
-    message: str
-
-
-class SensorsResult(BaseModel):
-    site_name: str
-    asset_id: str
-    total_sensors: int
-    sensors: List[str]
-    message: str
-
-
-class HistoryResult(BaseModel):
-    site_name: str
-    asset_id: str
-    total_observations: int
-    start: str
-    final: Optional[str]
-    observations: List[Dict[str, Any]]
-    message: str
-
-
-# ── Asset-registry result models (identity / nameplate + installed sensor names) ──
-class AssetDetail(BaseModel):
-    site_name: str
-    asset_id: str
-    description: Optional[str]
-    assettype: Optional[str]
-    status: Optional[str]
-    location: Optional[str]
-    installdate: Optional[str]
-    vintage: Optional[str]
-    n_sensors: int
-    message: str
-
-
-class AssetSensorsResult(BaseModel):
-    site_name: str
-    asset_id: str
-    total_sensors: int
-    sensors: List[str]
     message: str
 
 
@@ -138,123 +70,33 @@ class AssetsWithMetadataResult(BaseModel):
     message: str
 
 
-class RegistryAssetsResult(BaseModel):
-    site_name: str
-    total_assets: int
-    assets: List[Dict[str, Any]]
-    message: str
-
-
-_asset_list_cache: Optional[List[str]] = None
-
-
-def get_asset_list() -> List[str]:
-    """Helper to fetch unique asset IDs from CouchDB.  Result is cached after
-    the first successful call to avoid repeated full-table scans."""
-    global _asset_list_cache
-    if _asset_list_cache is not None:
-        return _asset_list_cache
-
-    if not db:
-        return []
-
-    try:
-        # We limit the fields to just asset_id to minimize data transfer
-        res = db.find(
-            {"asset_id": {"$exists": True}}, fields=["asset_id"], limit=100000
-        )
-        assets = {doc["asset_id"] for doc in res["docs"] if "asset_id" in doc}
-        _asset_list_cache = sorted(list(assets))
-        return _asset_list_cache
-    except Exception as e:
-        logger.error(f"Error fetching assets: {e}")
-        return []
-
-
-_sensor_list_cache: Dict[str, List[str]] = {}
-
-
-def get_sensor_list(asset_id: str) -> List[str]:
-    """The sensors an asset actually measures = the UNION of measurement keys across ALL of the
-    asset's reading documents.
-
-    IoT data may be sparse / non-uniform: different sensors are recorded at different timestamps
-    (a timestamp may carry one sensor, several, or all), so a single document does NOT reveal the
-    full measured set. We therefore scan every reading doc for the asset and union the non-metadata
-    keys. Result is cached per asset_id after the first successful call."""
-    if asset_id in _sensor_list_cache:
-        return _sensor_list_cache[asset_id]
-
-    if not db:
-        return []
-
-    try:
-        res = db.find({"asset_id": asset_id}, limit=100000)
-        docs = res["docs"]
-        if not docs:
-            return []
-
-        # Exclude metadata; union the measurement keys across every reading document.
-        exclude = {"_id", "_rev", "asset_id", "timestamp"}
-        sensors = sorted(
-            {key for doc in docs for key in doc.keys() if key not in exclude}
-        )
-        _sensor_list_cache[asset_id] = sensors
-        return sensors
-    except Exception as e:
-        logger.error(f"Error fetching sensors for {asset_id}: {e}")
-        return []
-
-
-_asset_doc_cache: Dict[str, Dict[str, Any]] = {}
-
-
-def get_asset_doc(asset_id: str) -> Optional[Dict[str, Any]]:
-    """Fetch one asset-registry document, resolving ANY of the asset's id spaces — the registry
-    `assetnum` (Maximo id), the telemetry `iot_asset_id`, or the work-order `wo_assetnum`. This lets
-    the same profile be found whether the caller holds the IoT id (e.g. 'Chiller 6') or the WO id
-    ('CHILLER6'). Cached per asset_id."""
-    if asset_id in _asset_doc_cache:
-        return _asset_doc_cache[asset_id]
-    if not asset_db:
-        return None
-    try:
-        for field in ("assetnum", "iot_asset_id", "wo_assetnum"):
-            res = asset_db.find({"doctype": "asset", field: asset_id}, limit=1)
-            docs = res["docs"]
-            if docs:
-                _asset_doc_cache[asset_id] = docs[0]
-                return docs[0]
-        return None
-    except Exception as e:
-        logger.error(f"Error fetching asset doc {asset_id}: {e}")
-        return None
-
-
 _registry_sites_cache: Optional[List[str]] = None
 
 
 def get_registry_sites() -> List[str]:
-    """Distinct site ids present in the asset registry (from each asset profile's `siteid`). Cached."""
+    """Return distinct site ids present in the asset registry."""
     global _registry_sites_cache
     if _registry_sites_cache is not None:
         return _registry_sites_cache
     if not asset_db:
         return []
     try:
-        res = asset_db.find({"doctype": "asset"}, fields=["siteid"], limit=100000)
-        found = sorted({d.get("siteid") for d in res["docs"] if d.get("siteid")})
-        _registry_sites_cache = found
-        return found
+        res = asset_db.find(
+            {"siteid": {"$exists": True}},
+            fields=["siteid"],
+            limit=100000,
+        )
+        _registry_sites_cache = sorted(
+            {doc.get("siteid") for doc in res["docs"] if doc.get("siteid")}
+        )
+        return _registry_sites_cache
     except Exception as e:
         logger.error(f"get_registry_sites failed: {e}")
         return []
 
 
 def known_sites() -> List[str]:
-    """The server's site list — discovered DYNAMICALLY from the asset registry (each asset profile's
-    `siteid`). Falls back to DEFAULT_SITES only if the registry is empty / unavailable.
-    """
+    """Return known registry sites, falling back to MAIN when the registry is unavailable."""
     return get_registry_sites() or DEFAULT_SITES
 
 
@@ -262,19 +104,11 @@ def _is_known_site(site_name: str) -> bool:
     return site_name in known_sites()
 
 
-@mcp.tool(title="List Sites")
-def sites() -> SitesResult:
-    """Retrieves the list of sites, discovered dynamically from the asset registry (the distinct
-    `siteid` across asset profiles). Falls back to the default only if the registry has no assets.
-    """
-    return SitesResult(sites=known_sites())
-
-
 @mcp.tool(title="List Asset IDs")
 def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
-    """Returns the asset IDs registered at a given site, from the asset registry filtered by `siteid`.
-    Each returned id is the asset's telemetry id (`iot_asset_id`) where it has one, otherwise its
-    registry `assetnum` — so the id works with sensors()/history() when telemetry exists.
+    """Return bare asset ids registered at a site.
+
+    Each returned id is the registry `assetnum`.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")
@@ -282,11 +116,11 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
         return ErrorResult(error="CouchDB not connected")
     try:
         res = asset_db.find(
-            {"doctype": "asset", "siteid": site_name},
-            fields=["assetnum", "iot_asset_id"],
+            {"siteid": site_name},
+            fields=["assetnum"],
             limit=100000,
         )
-        ids = sorted((d.get("iot_asset_id") or d["assetnum"]) for d in res["docs"])
+        ids = sorted(doc["assetnum"] for doc in res["docs"])
         return AssetsResult(
             site_name=site_name,
             total_assets=len(ids),
@@ -302,16 +136,17 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
 def assets(
     site_name: str, assettype: Optional[str] = None
 ) -> Union[AssetsWithMetadataResult, ErrorResult]:
-    """List assets at a site with metadata: description, assettype, vintage, and installed sensor
-    count. Optionally filter by `assettype` (e.g. 'PUMP', 'COMPRESSOR'). For just the bare IDs to
-    pass to other tools, use `asset_ids`.
+    """Return registry assets with metadata.
+
+    The result includes description, assettype, vintage, and installed sensor count. Optionally
+    filter by `assettype`, for example `PUMP` or `COMPRESSOR`.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")
     if not asset_db:
         return ErrorResult(error="CouchDB not connected")
     try:
-        selector: Dict[str, Any] = {"doctype": "asset", "siteid": site_name}
+        selector: Dict[str, Any] = {"siteid": site_name}
         if assettype:
             selector["assettype"] = assettype
         res = asset_db.find(
@@ -322,15 +157,15 @@ def assets(
         rows = sorted(
             (
                 AssetSummary(
-                    asset_id=d["assetnum"],
-                    assettype=d.get("assettype"),
-                    description=d.get("description"),
-                    vintage=d.get("vintage"),
-                    n_sensors=len(d.get("sensors", [])),
+                    asset_id=doc["assetnum"],
+                    assettype=doc.get("assettype"),
+                    description=doc.get("description"),
+                    vintage=doc.get("vintage"),
+                    n_sensors=len(doc.get("sensors", [])),
                 )
-                for d in res["docs"]
+                for doc in res["docs"]
             ),
-            key=lambda r: r.asset_id,
+            key=lambda row: row.asset_id,
         )
         return AssetsWithMetadataResult(
             site_name=site_name,
@@ -345,181 +180,7 @@ def assets(
         return ErrorResult(error=str(e))
 
 
-@mcp.tool(title="List Sensors")
-def sensors(site_name: str, asset_id: str) -> Union[SensorsResult, ErrorResult]:
-    """Lists the sensors available for a specified asset at a given site.
-    These are the MEASURED sensors — names discovered from the asset's telemetry documents,
-    i.e. points that actually stream to the historian. For the full INSTALLED inventory
-    (including sensors fitted but not streaming), use asset_sensors()."""
-    if not _is_known_site(site_name):
-        return ErrorResult(error=f"unknown site {site_name}")
-
-    sensor_list = get_sensor_list(asset_id)
-    if not sensor_list:
-        return ErrorResult(error=f"unknown asset_id {asset_id} or no sensors found")
-
-    return SensorsResult(
-        site_name=site_name,
-        asset_id=asset_id,
-        total_sensors=len(sensor_list),
-        sensors=sensor_list,
-        message=f"found {len(sensor_list)} sensors for asset_id {asset_id} and site_name {site_name}: {', '.join(sensor_list)}.",
-    )
-
-
-@mcp.tool(title="Get Sensor History")
-def history(
-    site_name: str, asset_id: str, start: str, final: Optional[str] = None
-) -> Union[HistoryResult, ErrorResult]:
-    """Returns a list of historical sensor values for the specified asset(s) at a site within a given time range (start to final)."""
-    try:
-        start_iso = datetime.fromisoformat(start).isoformat()
-        if final:
-            datetime.fromisoformat(final)
-            if start >= final:
-                return ErrorResult(error="start >= final")
-    except ValueError as e:
-        return ErrorResult(error=f"Invalid date format: {e}")
-
-    if not db:
-        return ErrorResult(error="CouchDB not connected")
-
-    selector = {
-        "asset_id": asset_id,
-        "timestamp": {"$gte": start_iso},
-    }
-    if final:
-        selector["timestamp"]["$lt"] = datetime.fromisoformat(final).isoformat()
-
-    logger.info(f"Querying CouchDB with selector: {selector}")
-    try:
-        res = db.find(
-            selector, limit=1000, sort=[{"asset_id": "asc"}, {"timestamp": "asc"}]
-        )
-        docs = res["docs"]
-        return HistoryResult(
-            site_name=site_name,
-            asset_id=asset_id,
-            total_observations=len(docs),
-            start=start,
-            final=final,
-            observations=docs,
-            message=f"found {len(docs)} observations for asset_id {asset_id} from {start} to {final or 'now'}.",
-        )
-    except Exception as e:
-        logger.error(f"CouchDB query failed: {e}")
-        return ErrorResult(error=str(e))
-
-
-@mcp.tool(title="Get Asset")
-def get_asset(site_name: str, asset_id: str) -> Union[AssetDetail, ErrorResult]:
-    """Return registry/nameplate details for one asset (Maximo MXASSET-aligned: description,
-    assettype, status, location, installdate, vintage) plus installed sensor count.
-    This is asset IDENTITY — distinct from the telemetry-derived assets() list."""
-    if not _is_known_site(site_name):
-        return ErrorResult(error=f"unknown site {site_name}")
-    doc = get_asset_doc(asset_id)
-    if not doc:
-        return ErrorResult(error=f"unknown asset_id {asset_id} in registry")
-    n = len(doc.get("sensors", []))
-    assettype = doc.get("assettype")
-    vintage = doc.get("vintage")
-    location = doc.get("location")
-
-    # Build a human message that omits clauses whose fields are null.
-    parts = [f"asset {asset_id} is a {assettype or 'asset'}"]
-    if vintage:
-        parts.append(f" ({vintage} vintage)")
-    if location:
-        parts.append(f" at {location}")
-    parts.append(f" with {n} installed sensors.")
-    message = "".join(parts)
-
-    return AssetDetail(
-        site_name=site_name,
-        asset_id=doc.get("assetnum", asset_id),
-        description=doc.get("description"),
-        assettype=assettype,
-        status=doc.get("status"),
-        location=location,
-        installdate=doc.get("installdate"),
-        vintage=vintage,
-        n_sensors=n,
-        message=message,
-    )
-
-
-@mcp.tool(title="List Asset Sensors")
-def asset_sensors(
-    site_name: str, asset_id: str
-) -> Union[AssetSensorsResult, ErrorResult]:
-    """List the INSTALLED sensors for an asset, by name (installed is assumed). This is the registry
-    inventory — distinct from sensors(), which lists only what actually streams (the MEASURED set).
-    Compare the two to find installed-but-not-streaming sensors."""
-    if not _is_known_site(site_name):
-        return ErrorResult(error=f"unknown site {site_name}")
-    doc = get_asset_doc(asset_id)
-    if not doc:
-        return ErrorResult(error=f"unknown asset_id {asset_id} in registry")
-    names = list(doc.get("sensors", []))
-    return AssetSensorsResult(
-        site_name=site_name,
-        asset_id=asset_id,
-        total_sensors=len(names),
-        sensors=names,
-        message=f"{len(names)} sensors installed on {asset_id}: {', '.join(names)}.",
-    )
-
-
-@mcp.tool(title="List Registry Assets")
-def registry_assets(
-    site_name: str, assettype: Optional[str] = None
-) -> Union[RegistryAssetsResult, ErrorResult]:
-    """List assets from the registry with metadata (assettype, vintage, sensor count), optionally
-    filtered by assettype (e.g. 'PUMP', 'COMPRESSOR'). Complements assets(), which returns bare ids derived from
-    telemetry."""
-
-    if not _is_known_site(site_name):
-        return ErrorResult(error=f"unknown site {site_name}")
-    if not asset_db:
-        return ErrorResult(error="CouchDB not connected")
-    try:
-        selector: Dict[str, Any] = {"doctype": "asset", "siteid": site_name}
-        if assettype:
-            selector["assettype"] = assettype
-        res = asset_db.find(
-            selector,
-            fields=["assetnum", "assettype", "description", "vintage", "sensors"],
-            limit=100000,
-        )
-        rows = sorted(
-            (
-                {
-                    "asset_id": d["assetnum"],
-                    "assettype": d.get("assettype"),
-                    "description": d.get("description"),
-                    "vintage": d.get("vintage"),
-                    "n_sensors": len(d.get("sensors", [])),
-                }
-                for d in res["docs"]
-            ),
-            key=lambda r: r["asset_id"],
-        )
-        return RegistryAssetsResult(
-            site_name=site_name,
-            total_assets=len(rows),
-            assets=rows,
-            message=f"found {len(rows)} registry assets"
-            + (f" of type '{assettype}'" if assettype else "")
-            + ".",
-        )
-    except Exception as e:
-        logger.error(f"registry_assets failed: {e}")
-        return ErrorResult(error=str(e))
-
-
 def main():
-    # Initialize and run the server
     mcp.run(transport="stdio")
 
 

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -36,8 +36,9 @@ except Exception as e:
 mcp = FastMCP(
     "iot",
     instructions=(
-        "IoT asset registry tools. This server only exposes asset_ids(), for bare assetnum "
-        "values, and assets(), for registry metadata with optional assettype filtering."
+        "IoT asset registry tools. Use sites() to discover site names, asset_ids() for bare "
+        "assetnum values at a site, and assets() for registry metadata with optional "
+        "assettype filtering."
     ),
 )
 
@@ -46,6 +47,10 @@ DEFAULT_SITES = ["MAIN"]
 
 class ErrorResult(BaseModel):
     error: str
+
+
+class SitesResult(BaseModel):
+    sites: List[str]
 
 
 class AssetsResult(BaseModel):
@@ -104,11 +109,26 @@ def _is_known_site(site_name: str) -> bool:
     return site_name in known_sites()
 
 
+@mcp.tool(title="List Sites")
+def sites() -> SitesResult:
+    """List known site names from the asset registry.
+
+    Sites are discovered from distinct `siteid` values in asset profiles. If the registry is
+    unavailable or empty, the tool returns the default site list so callers still have a valid
+    starting point for `asset_ids()` and `assets()`.
+    """
+    return SitesResult(sites=known_sites())
+
+
 @mcp.tool(title="List Asset IDs")
 def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
-    """Return bare asset ids registered at a site.
+    """List only the asset identifiers for a site.
 
-    Each returned id is the registry `assetnum`.
+    Use this lightweight lookup when you only need valid `assetnum` values, for example to
+    populate a selector, validate an asset reference, or choose an id for another workflow.
+    The response contains no metadata beyond `site_name`, `total_assets`, the sorted `assets`
+    id list, and a human-readable summary. Use `assets()` instead when you need descriptions,
+    asset types, vintages, or installed sensor counts.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")
@@ -136,10 +156,12 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
 def assets(
     site_name: str, assettype: Optional[str] = None
 ) -> Union[AssetsWithMetadataResult, ErrorResult]:
-    """Return registry assets with metadata.
+    """List asset registry records for a site with compact metadata.
 
-    The result includes description, assettype, vintage, and installed sensor count. Optionally
-    filter by `assettype`, for example `PUMP` or `COMPRESSOR`.
+    Use this when you need more than ids: each row includes `asset_id` (the registry
+    `assetnum`), `description`, `assettype`, `vintage`, and `n_sensors` derived from the
+    installed sensor list. Pass `assettype` to restrict results to one asset class, such as
+    `PUMP` or `COMPRESSOR`. Use `asset_ids()` instead when a compact list of ids is enough.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -111,24 +111,33 @@ def _is_known_site(site_name: str) -> bool:
 
 @mcp.tool(title="List Sites")
 def sites() -> SitesResult:
-    """List known site names from the asset registry.
+    """Description:
+    List known site names from the asset registry.
 
-    Sites are discovered from distinct `siteid` values in asset profiles. If the registry is
-    unavailable or empty, the tool returns the default site list so callers still have a valid
-    starting point for `asset_ids()` and `assets()`.
+    Input:
+    None.
+
+    Returns:
+    SitesResult with `sites`, a sorted list of distinct `siteid` values from
+    asset profiles. If CouchDB is unavailable or the registry has no sites,
+    returns the default site list (`["MAIN"]`).
     """
     return SitesResult(sites=known_sites())
 
 
 @mcp.tool(title="List Asset IDs")
 def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
-    """List only the asset identifiers for a site.
+    """Description:
+    List only asset identifiers for one site.
 
-    Use this lightweight lookup when you only need valid `assetnum` values, for example to
-    populate a selector, validate an asset reference, or choose an id for another workflow.
-    The response contains no metadata beyond `site_name`, `total_assets`, the sorted `assets`
-    id list, and a human-readable summary. Use `assets()` instead when you need descriptions,
-    asset types, vintages, or installed sensor counts.
+    Input:
+    site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
+        discover valid site ids.
+
+    Returns:
+    AssetsResult with `site_name`, `total_assets`, `assets`, and `message`.
+    The `assets` field is a sorted list of asset registry `assetnum` values.
+    Returns ErrorResult when the site is unknown or CouchDB is unavailable.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")
@@ -156,12 +165,20 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
 def assets(
     site_name: str, assettype: Optional[str] = None
 ) -> Union[AssetsWithMetadataResult, ErrorResult]:
-    """List asset registry records for a site with compact metadata.
+    """Description:
+    List asset registry records for one site with compact metadata.
 
-    Use this when you need more than ids: each row includes `asset_id` (the registry
-    `assetnum`), `description`, `assettype`, `vintage`, and `n_sensors` derived from the
-    installed sensor list. Pass `assettype` to restrict results to one asset class, such as
-    `PUMP` or `COMPRESSOR`. Use `asset_ids()` instead when a compact list of ids is enough.
+    Input:
+    site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
+        discover valid site ids.
+    assettype: Optional exact asset type filter, such as `PUMP` or
+        `COMPRESSOR`.
+
+    Returns:
+    AssetsWithMetadataResult with `site_name`, `total_assets`, `assets`, and
+    `message`. Each item in `assets` includes `asset_id` (the registry
+    `assetnum`), `description`, `assettype`, `vintage`, and `n_sensors`.
+    Returns ErrorResult when the site is unknown or CouchDB is unavailable.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -111,33 +111,30 @@ def _is_known_site(site_name: str) -> bool:
 
 @mcp.tool(title="List Sites")
 def sites() -> SitesResult:
-    """Description:
-    List known site names from the asset registry.
-
-    Input:
-    None.
+    """List known site names from the asset registry.
 
     Returns:
-    SitesResult with `sites`, a sorted list of distinct `siteid` values from
-    asset profiles. If CouchDB is unavailable or the registry has no sites,
-    returns the default site list (`["MAIN"]`).
+        SitesResult: `sites` contains sorted distinct `siteid` values from
+        asset profiles. If CouchDB is unavailable or the registry has no sites,
+        `sites` falls back to `["MAIN"]`.
     """
     return SitesResult(sites=known_sites())
 
 
 @mcp.tool(title="List Asset IDs")
 def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
-    """Description:
-    List only asset identifiers for one site.
+    """List only asset identifiers for one site.
 
-    Input:
-    site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
-        discover valid site ids.
+    Args:
+        site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
+            discover valid site ids.
 
     Returns:
-    AssetsResult with `site_name`, `total_assets`, `assets`, and `message`.
-    The `assets` field is a sorted list of asset registry `assetnum` values.
-    Returns ErrorResult when the site is unknown or CouchDB is unavailable.
+        AssetsResult: Contains `site_name`, `total_assets`, `assets`, and
+        `message`. The `assets` field is a sorted list of asset registry
+        `assetnum` values.
+        ErrorResult: Returned when the site is unknown or CouchDB is
+        unavailable.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")
@@ -165,20 +162,21 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
 def assets(
     site_name: str, assettype: Optional[str] = None
 ) -> Union[AssetsWithMetadataResult, ErrorResult]:
-    """Description:
-    List asset registry records for one site with compact metadata.
+    """List asset registry records for one site with compact metadata.
 
-    Input:
-    site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
-        discover valid site ids.
-    assettype: Optional exact asset type filter, such as `PUMP` or
-        `COMPRESSOR`.
+    Args:
+        site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
+            discover valid site ids.
+        assettype: Optional exact asset type filter, such as `PUMP` or
+            `COMPRESSOR`.
 
     Returns:
-    AssetsWithMetadataResult with `site_name`, `total_assets`, `assets`, and
-    `message`. Each item in `assets` includes `asset_id` (the registry
-    `assetnum`), `description`, `assettype`, `vintage`, and `n_sensors`.
-    Returns ErrorResult when the site is unknown or CouchDB is unavailable.
+        AssetsWithMetadataResult: Contains `site_name`, `total_assets`,
+        `assets`, and `message`. Each item in `assets` includes `asset_id`
+        (the registry `assetnum`), `description`, `assettype`, `vintage`, and
+        `n_sensors`.
+        ErrorResult: Returned when the site is unknown or CouchDB is
+        unavailable.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -28,9 +28,9 @@ try:
         user=COUCHDB_USERNAME,
         password=COUCHDB_PASSWORD,
     )
-    logger.info(f"Connected to CouchDB: {ASSET_DBNAME}")
+    logger.info(f"Connected to asset registry database: {ASSET_DBNAME}")
 except Exception as e:
-    logger.error(f"Failed to connect to asset registry DB: {e}")
+    logger.error(f"Failed to connect to asset registry database: {e}")
     asset_db = None
 
 mcp = FastMCP(
@@ -115,7 +115,7 @@ def sites() -> SitesResult:
 
     Returns:
         SitesResult: `sites` contains sorted distinct `siteid` values from
-        asset profiles. If CouchDB is unavailable or the registry has no sites,
+        asset profiles. If the registry database is unavailable or has no sites,
         `sites` falls back to `["MAIN"]`.
     """
     return SitesResult(sites=known_sites())
@@ -133,13 +133,13 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
         AssetsResult: Contains `site_name`, `total_assets`, `assets`, and
         `message`. The `assets` field is a sorted list of asset registry
         `assetnum` values.
-        ErrorResult: Returned when the site is unknown or CouchDB is
-        unavailable.
+        ErrorResult: Returned when the site is unknown or the registry database
+        is unavailable.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")
     if not asset_db:
-        return ErrorResult(error="CouchDB not connected")
+        return ErrorResult(error="asset registry database not connected")
     try:
         res = asset_db.find(
             {"siteid": site_name},
@@ -175,13 +175,13 @@ def assets(
         `assets`, and `message`. Each item in `assets` includes `asset_id`
         (the registry `assetnum`), `description`, `assettype`, `vintage`, and
         `n_sensors`.
-        ErrorResult: Returned when the site is unknown or CouchDB is
-        unavailable.
+        ErrorResult: Returned when the site is unknown or the registry database
+        is unavailable.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")
     if not asset_db:
-        return ErrorResult(error="CouchDB not connected")
+        return ErrorResult(error="asset registry database not connected")
     try:
         selector: Dict[str, Any] = {"siteid": site_name}
         if assettype:

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -133,8 +133,6 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
         AssetsResult: Contains `site_name`, `total_assets`, `assets`, and
         `message`. The `assets` field is a sorted list of asset registry
         `assetnum` values.
-        ErrorResult: Returned when the site is unknown or the registry database
-        is unavailable.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")
@@ -175,8 +173,6 @@ def assets(
         `assets`, and `message`. Each item in `assets` includes `asset_id`
         (the registry `assetnum`), `description`, `assettype`, `vintage`, and
         `n_sensors`.
-        ErrorResult: Returned when the site is unknown or the registry database
-        is unavailable.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -58,9 +58,10 @@ mcp = FastMCP(
     instructions=(
         "IoT sensor data + asset registry. Browse sites, assets, and sensors, read the asset "
         "nameplate (registry), see which installed sensors are actually measured (streaming), and "
-        "query historical readings from CouchDB. NOTE: assets()/sensors() reflect TELEMETRY (what "
-        "streams = measured); get_asset()/asset_sensors()/registry_assets() reflect the REGISTRY "
-        "(what is installed, by name). Compare the two to find installed-but-not-streaming sensors."
+        "query historical readings from CouchDB. NOTE: asset_ids() lists IDs to pass to telemetry "
+        "tools; sensors() reflects TELEMETRY (what streams = measured); assets()/get_asset()/"
+        "asset_sensors()/registry_assets() reflect the REGISTRY (what is installed, by name). "
+        "Compare the two to find installed-but-not-streaming sensors."
     ),
 )
 
@@ -119,6 +120,21 @@ class AssetSensorsResult(BaseModel):
     asset_id: str
     total_sensors: int
     sensors: List[str]
+    message: str
+
+
+class AssetSummary(BaseModel):
+    asset_id: str
+    description: Optional[str]
+    assettype: Optional[str]
+    vintage: Optional[str]
+    n_sensors: int
+
+
+class AssetsWithMetadataResult(BaseModel):
+    site_name: str
+    total_assets: int
+    assets: List[AssetSummary]
     message: str
 
 
@@ -254,9 +270,9 @@ def sites() -> SitesResult:
     return SitesResult(sites=known_sites())
 
 
-@mcp.tool(title="List Assets")
-def assets(site_name: str) -> Union[AssetsResult, ErrorResult]:
-    """Returns the assets registered at a given site, from the asset registry filtered by `siteid`.
+@mcp.tool(title="List Asset IDs")
+def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
+    """Returns the asset IDs registered at a given site, from the asset registry filtered by `siteid`.
     Each returned id is the asset's telemetry id (`iot_asset_id`) where it has one, otherwise its
     registry `assetnum` — so the id works with sensors()/history() when telemetry exists.
     """
@@ -276,6 +292,53 @@ def assets(site_name: str) -> Union[AssetsResult, ErrorResult]:
             total_assets=len(ids),
             assets=ids,
             message=f"found {len(ids)} assets at site {site_name}: {', '.join(ids)}.",
+        )
+    except Exception as e:
+        logger.error(f"asset_ids failed: {e}")
+        return ErrorResult(error=str(e))
+
+
+@mcp.tool(title="List Assets")
+def assets(
+    site_name: str, assettype: Optional[str] = None
+) -> Union[AssetsWithMetadataResult, ErrorResult]:
+    """List assets at a site with metadata: description, assettype, vintage, and installed sensor
+    count. Optionally filter by `assettype` (e.g. 'PUMP', 'COMPRESSOR'). For just the bare IDs to
+    pass to other tools, use `asset_ids`.
+    """
+    if not _is_known_site(site_name):
+        return ErrorResult(error=f"unknown site {site_name}")
+    if not asset_db:
+        return ErrorResult(error="CouchDB not connected")
+    try:
+        selector: Dict[str, Any] = {"doctype": "asset", "siteid": site_name}
+        if assettype:
+            selector["assettype"] = assettype
+        res = asset_db.find(
+            selector,
+            fields=["assetnum", "assettype", "description", "vintage", "sensors"],
+            limit=100000,
+        )
+        rows = sorted(
+            (
+                AssetSummary(
+                    asset_id=d["assetnum"],
+                    assettype=d.get("assettype"),
+                    description=d.get("description"),
+                    vintage=d.get("vintage"),
+                    n_sensors=len(d.get("sensors", [])),
+                )
+                for d in res["docs"]
+            ),
+            key=lambda r: r.asset_id,
+        )
+        return AssetsWithMetadataResult(
+            site_name=site_name,
+            total_assets=len(rows),
+            assets=rows,
+            message=f"found {len(rows)} assets"
+            + (f" of type '{assettype}'" if assettype else "")
+            + ".",
         )
     except Exception as e:
         logger.error(f"assets failed: {e}")

--- a/src/servers/iot/tests/conftest.py
+++ b/src/servers/iot/tests/conftest.py
@@ -12,31 +12,21 @@ load_dotenv()
 
 def _couchdb_reachable() -> bool:
     url = os.environ.get("COUCHDB_URL")
-    iot_dbname = os.environ.get("IOT_DBNAME")
-    if not url or not iot_dbname:
+    if not url:
         return False
     try:
         import couchdb3
 
         username = os.environ.get("COUCHDB_USERNAME")
         password = os.environ.get("COUCHDB_PASSWORD")
-        iot_db = couchdb3.Database(
-            iot_dbname,
-            url=url,
-            user=username,
-            password=password,
-        )
         asset_db = couchdb3.Database(
             os.environ.get("ASSET_DBNAME", "asset"),
             url=url,
             user=username,
             password=password,
         )
-        telemetry = iot_db.find({"asset_id": "Chiller 6"}, limit=1)["docs"]
-        registry = asset_db.find(
-            {"doctype": "asset", "iot_asset_id": "Chiller 6"}, limit=1
-        )["docs"]
-        return bool(telemetry and registry)
+        registry = asset_db.find({"assetnum": "Chiller 6"}, limit=1)["docs"]
+        return bool(registry)
     except Exception:
         return False
 
@@ -44,8 +34,8 @@ def _couchdb_reachable() -> bool:
 requires_couchdb = pytest.mark.skipif(
     not _couchdb_reachable(),
     reason=(
-        "CouchDB sample IoT data not available "
-        "(set COUCHDB_URL/IOT_DBNAME and load the Chiller 6 sample data)"
+        "CouchDB sample asset registry not available "
+        "(set COUCHDB_URL and load the Chiller 6 asset profile)"
     ),
 )
 
@@ -54,24 +44,10 @@ requires_couchdb = pytest.mark.skipif(
 
 
 @pytest.fixture
-def mock_db():
-    """Patch the module-level `db` object in main with a mock."""
-    with patch("servers.iot.main.db") as mock:
-        yield mock
-
-
-@pytest.fixture
 def mock_asset_db():
     """Patch the module-level `asset_db` object in main with a mock."""
     with patch("servers.iot.main.asset_db") as mock:
         yield mock
-
-
-@pytest.fixture
-def no_db():
-    """Patch the module-level `db` to None (simulate disconnected CouchDB)."""
-    with patch("servers.iot.main.db", None):
-        yield
 
 
 @pytest.fixture
@@ -86,14 +62,8 @@ def clear_iot_caches():
     """Clear module-level caches so mocked DB responses do not leak across tests."""
     import servers.iot.main as iot_main
 
-    iot_main._asset_list_cache = None
-    iot_main._sensor_list_cache.clear()
-    iot_main._asset_doc_cache.clear()
     iot_main._registry_sites_cache = None
     yield
-    iot_main._asset_list_cache = None
-    iot_main._sensor_list_cache.clear()
-    iot_main._asset_doc_cache.clear()
     iot_main._registry_sites_cache = None
 
 

--- a/src/servers/iot/tests/conftest.py
+++ b/src/servers/iot/tests/conftest.py
@@ -12,20 +12,41 @@ load_dotenv()
 
 def _couchdb_reachable() -> bool:
     url = os.environ.get("COUCHDB_URL")
-    if not url:
+    iot_dbname = os.environ.get("IOT_DBNAME")
+    if not url or not iot_dbname:
         return False
     try:
-        import requests
+        import couchdb3
 
-        requests.get(url, timeout=2)
-        return True
+        username = os.environ.get("COUCHDB_USERNAME")
+        password = os.environ.get("COUCHDB_PASSWORD")
+        iot_db = couchdb3.Database(
+            iot_dbname,
+            url=url,
+            user=username,
+            password=password,
+        )
+        asset_db = couchdb3.Database(
+            os.environ.get("ASSET_DBNAME", "asset"),
+            url=url,
+            user=username,
+            password=password,
+        )
+        telemetry = iot_db.find({"asset_id": "Chiller 6"}, limit=1)["docs"]
+        registry = asset_db.find(
+            {"doctype": "asset", "iot_asset_id": "Chiller 6"}, limit=1
+        )["docs"]
+        return bool(telemetry and registry)
     except Exception:
         return False
 
 
 requires_couchdb = pytest.mark.skipif(
     not _couchdb_reachable(),
-    reason="CouchDB not reachable (set COUCHDB_URL and ensure CouchDB is running)",
+    reason=(
+        "CouchDB sample IoT data not available "
+        "(set COUCHDB_URL/IOT_DBNAME and load the Chiller 6 sample data)"
+    ),
 )
 
 
@@ -40,10 +61,40 @@ def mock_db():
 
 
 @pytest.fixture
+def mock_asset_db():
+    """Patch the module-level `asset_db` object in main with a mock."""
+    with patch("servers.iot.main.asset_db") as mock:
+        yield mock
+
+
+@pytest.fixture
 def no_db():
     """Patch the module-level `db` to None (simulate disconnected CouchDB)."""
     with patch("servers.iot.main.db", None):
         yield
+
+
+@pytest.fixture
+def no_asset_db():
+    """Patch the module-level `asset_db` to None (simulate disconnected CouchDB)."""
+    with patch("servers.iot.main.asset_db", None):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def clear_iot_caches():
+    """Clear module-level caches so mocked DB responses do not leak across tests."""
+    import servers.iot.main as iot_main
+
+    iot_main._asset_list_cache = None
+    iot_main._sensor_list_cache.clear()
+    iot_main._asset_doc_cache.clear()
+    iot_main._registry_sites_cache = None
+    yield
+    iot_main._asset_list_cache = None
+    iot_main._sensor_list_cache.clear()
+    iot_main._asset_doc_cache.clear()
+    iot_main._registry_sites_cache = None
 
 
 async def call_tool(mcp_instance, tool_name: str, args: dict) -> dict:

--- a/src/servers/iot/tests/test_couchdb.py
+++ b/src/servers/iot/tests/test_couchdb.py
@@ -1,4 +1,4 @@
-"""Infrastructure tests: verify CouchDB connectivity and sample data."""
+"""Infrastructure tests: verify CouchDB connectivity and sample registry data."""
 
 import os
 
@@ -15,7 +15,7 @@ COUCHDB_URL = os.environ.get("COUCHDB_URL", "")
 COUCHDB_HOST = COUCHDB_URL.replace("http://", "").replace("https://", "")
 COUCHDB_USERNAME = os.environ.get("COUCHDB_USERNAME", "")
 COUCHDB_PASSWORD = os.environ.get("COUCHDB_PASSWORD", "")
-COUCHDB_DBNAME = os.environ.get("IOT_DBNAME", "")
+ASSET_DBNAME = os.environ.get("ASSET_DBNAME", "asset")
 
 FULL_URL = f"http://{COUCHDB_USERNAME}:{COUCHDB_PASSWORD}@{COUCHDB_HOST}"
 
@@ -37,10 +37,10 @@ class TestCouchDBInfrastructure:
         assert client.info() is not None
 
     def test_database_exists(self, couchdb_client):
-        assert COUCHDB_DBNAME in couchdb_client.all_dbs()
+        assert ASSET_DBNAME in couchdb_client.all_dbs()
 
     def test_sample_data_populated(self, couchdb_client):
-        db = couchdb_client[COUCHDB_DBNAME]
-        res = db.find({"asset_id": "Chiller 6"}, limit=1)
+        db = couchdb_client[ASSET_DBNAME]
+        res = db.find({"assetnum": "Chiller 6"}, limit=1)
         assert len(res["docs"]) > 0
-        assert res["docs"][0]["asset_id"] == "Chiller 6"
+        assert res["docs"][0]["assetnum"] == "Chiller 6"

--- a/src/servers/iot/tests/test_tools.py
+++ b/src/servers/iot/tests/test_tools.py
@@ -8,9 +8,25 @@ from .conftest import call_tool, requires_couchdb
 
 class TestToolRegistration:
     @pytest.mark.anyio
-    async def test_only_asset_tools_are_registered(self):
+    async def test_registry_tools_are_registered(self):
         tools = await mcp.list_tools()
-        assert sorted(tool.name for tool in tools) == ["asset_ids", "assets"]
+        assert sorted(tool.name for tool in tools) == ["asset_ids", "assets", "sites"]
+
+
+class TestSites:
+    @pytest.mark.anyio
+    async def test_returns_known_sites(self, mock_asset_db):
+        mock_asset_db.find.return_value = {
+            "docs": [{"siteid": "MAIN"}, {"siteid": "NORTH"}, {"siteid": "MAIN"}]
+        }
+        data = await call_tool(mcp, "sites", {})
+
+        assert data["sites"] == ["MAIN", "NORTH"]
+
+    @pytest.mark.anyio
+    async def test_falls_back_to_default_site(self, no_asset_db):
+        data = await call_tool(mcp, "sites", {})
+        assert data["sites"] == ["MAIN"]
 
 
 class TestAssetIds:

--- a/src/servers/iot/tests/test_tools.py
+++ b/src/servers/iot/tests/test_tools.py
@@ -18,7 +18,50 @@ class TestSites:
     @pytest.mark.anyio
     async def test_returns_main(self):
         data = await call_tool(mcp, "sites", {})
-        assert data["sites"] == ["MAIN"]
+        assert "MAIN" in data["sites"]
+
+
+# ---------------------------------------------------------------------------
+# asset_ids
+# ---------------------------------------------------------------------------
+
+
+class TestAssetIds:
+    @pytest.mark.anyio
+    async def test_invalid_site(self):
+        data = await call_tool(mcp, "asset_ids", {"site_name": "INVALID"})
+        assert "error" in data
+        assert "unknown site" in data["error"]
+
+    @pytest.mark.anyio
+    async def test_with_mock_asset_db(self, mock_asset_db):
+        mock_asset_db.find.side_effect = [
+            {"docs": [{"siteid": "MAIN"}]},
+            {
+                "docs": [
+                    {"assetnum": "CHILLER6", "iot_asset_id": "Chiller 6"},
+                    {"assetnum": "PUMP3", "iot_asset_id": None},
+                ]
+            },
+        ]
+        data = await call_tool(mcp, "asset_ids", {"site_name": "MAIN"})
+
+        assert data["total_assets"] == 2
+        assert data["assets"] == ["Chiller 6", "PUMP3"]
+
+    @pytest.mark.anyio
+    async def test_db_disconnected(self, no_asset_db):
+        data = await call_tool(mcp, "asset_ids", {"site_name": "MAIN"})
+        assert "error" in data
+        assert "not connected" in data["error"].lower()
+
+    @requires_couchdb
+    @pytest.mark.anyio
+    async def test_discovery_integration(self):
+        data = await call_tool(mcp, "asset_ids", {"site_name": "MAIN"})
+        assert "assets" in data
+        assert "Chiller 6" in data["assets"]
+        assert data["total_assets"] > 0
 
 
 # ---------------------------------------------------------------------------
@@ -34,29 +77,77 @@ class TestAssets:
         assert "unknown site" in data["error"]
 
     @pytest.mark.anyio
-    async def test_with_mock_db(self, mock_db):
-        mock_db.find.return_value = {
-            "docs": [{"asset_id": "Chiller 1"}, {"asset_id": "Chiller 2"}]
-        }
+    async def test_with_mock_asset_db(self, mock_asset_db):
+        mock_asset_db.find.side_effect = [
+            {"docs": [{"siteid": "MAIN"}]},
+            {
+                "docs": [
+                    {
+                        "assetnum": "CHILLER6",
+                        "assettype": "CHILLER",
+                        "description": "Chiller 6",
+                        "vintage": None,
+                        "sensors": ["Supply Temperature", "Return Temperature"],
+                    },
+                    {
+                        "assetnum": "PUMP3",
+                        "assettype": "PUMP",
+                        "description": "Pump 3",
+                        "vintage": "new",
+                        "sensors": [],
+                    },
+                ]
+            },
+        ]
         data = await call_tool(mcp, "assets", {"site_name": "MAIN"})
 
         assert data["total_assets"] == 2
-        assert "Chiller 1" in data["assets"]
-        assert "Chiller 2" in data["assets"]
-        mock_db.find.assert_called_once()
+        assert data["assets"][0] == {
+            "asset_id": "CHILLER6",
+            "description": "Chiller 6",
+            "assettype": "CHILLER",
+            "vintage": None,
+            "n_sensors": 2,
+        }
+        assert data["assets"][1]["asset_id"] == "PUMP3"
 
     @pytest.mark.anyio
-    async def test_db_disconnected(self, no_db):
+    async def test_filters_by_assettype(self, mock_asset_db):
+        mock_asset_db.find.side_effect = [
+            {"docs": [{"siteid": "MAIN"}]},
+            {
+                "docs": [
+                    {
+                        "assetnum": "PUMP3",
+                        "assettype": "PUMP",
+                        "description": "Pump 3",
+                        "vintage": None,
+                        "sensors": [],
+                    }
+                ]
+            },
+        ]
+        data = await call_tool(
+            mcp, "assets", {"site_name": "MAIN", "assettype": "PUMP"}
+        )
+
+        assert data["total_assets"] == 1
+        assert data["assets"][0]["assettype"] == "PUMP"
+        selector = mock_asset_db.find.call_args_list[1].args[0]
+        assert selector["assettype"] == "PUMP"
+
+    @pytest.mark.anyio
+    async def test_db_disconnected(self, no_asset_db):
         data = await call_tool(mcp, "assets", {"site_name": "MAIN"})
-        # Should still return valid JSON (empty assets), not crash
-        assert "assets" in data or "error" in data
+        assert "error" in data
+        assert "not connected" in data["error"].lower()
 
     @requires_couchdb
     @pytest.mark.anyio
     async def test_discovery_integration(self):
         data = await call_tool(mcp, "assets", {"site_name": "MAIN"})
         assert "assets" in data
-        assert "Chiller 6" in data["assets"]
+        assert any(asset["asset_id"] == "CHILLER6" for asset in data["assets"])
         assert data["total_assets"] > 0
 
 

--- a/src/servers/iot/tests/test_tools.py
+++ b/src/servers/iot/tests/test_tools.py
@@ -1,29 +1,16 @@
-"""Tests for IoT MCP server tools.
-
-Unit tests use a mocked CouchDB; integration tests require a live instance
-(skipped unless COUCHDB_URL is set).
-"""
+"""Tests for IoT MCP server tools."""
 
 import pytest
+
 from servers.iot.main import mcp
-from .conftest import requires_couchdb, call_tool
+from .conftest import call_tool, requires_couchdb
 
 
-# ---------------------------------------------------------------------------
-# sites
-# ---------------------------------------------------------------------------
-
-
-class TestSites:
+class TestToolRegistration:
     @pytest.mark.anyio
-    async def test_returns_main(self):
-        data = await call_tool(mcp, "sites", {})
-        assert "MAIN" in data["sites"]
-
-
-# ---------------------------------------------------------------------------
-# asset_ids
-# ---------------------------------------------------------------------------
+    async def test_only_asset_tools_are_registered(self):
+        tools = await mcp.list_tools()
+        assert sorted(tool.name for tool in tools) == ["asset_ids", "assets"]
 
 
 class TestAssetIds:
@@ -39,8 +26,8 @@ class TestAssetIds:
             {"docs": [{"siteid": "MAIN"}]},
             {
                 "docs": [
-                    {"assetnum": "CHILLER6", "iot_asset_id": "Chiller 6"},
-                    {"assetnum": "PUMP3", "iot_asset_id": None},
+                    {"assetnum": "Chiller 6"},
+                    {"assetnum": "PUMP3"},
                 ]
             },
         ]
@@ -64,11 +51,6 @@ class TestAssetIds:
         assert data["total_assets"] > 0
 
 
-# ---------------------------------------------------------------------------
-# assets
-# ---------------------------------------------------------------------------
-
-
 class TestAssets:
     @pytest.mark.anyio
     async def test_invalid_site(self):
@@ -83,7 +65,7 @@ class TestAssets:
             {
                 "docs": [
                     {
-                        "assetnum": "CHILLER6",
+                        "assetnum": "Chiller 6",
                         "assettype": "CHILLER",
                         "description": "Chiller 6",
                         "vintage": None,
@@ -103,7 +85,7 @@ class TestAssets:
 
         assert data["total_assets"] == 2
         assert data["assets"][0] == {
-            "asset_id": "CHILLER6",
+            "asset_id": "Chiller 6",
             "description": "Chiller 6",
             "assettype": "CHILLER",
             "vintage": None,
@@ -147,162 +129,5 @@ class TestAssets:
     async def test_discovery_integration(self):
         data = await call_tool(mcp, "assets", {"site_name": "MAIN"})
         assert "assets" in data
-        assert any(asset["asset_id"] == "CHILLER6" for asset in data["assets"])
+        assert any(asset["asset_id"] == "Chiller 6" for asset in data["assets"])
         assert data["total_assets"] > 0
-
-
-# ---------------------------------------------------------------------------
-# sensors
-# ---------------------------------------------------------------------------
-
-
-class TestSensors:
-    @pytest.mark.anyio
-    async def test_invalid_site(self):
-        data = await call_tool(
-            mcp, "sensors", {"site_name": "INVALID", "asset_id": "Chiller 6"}
-        )
-        assert "error" in data
-
-    @pytest.mark.anyio
-    async def test_unknown_asset(self):
-        data = await call_tool(
-            mcp, "sensors", {"site_name": "MAIN", "asset_id": "INVALID"}
-        )
-        assert "error" in data
-        assert "no sensors found" in data["error"]
-
-    @pytest.mark.anyio
-    async def test_with_mock_db(self, mock_db):
-        mock_db.find.return_value = {
-            "docs": [
-                {
-                    "asset_id": "Chiller 1",
-                    "timestamp": "2024-01-01T00:00:00",
-                    "Temp": 25.5,
-                    "Pressure": 10.2,
-                    "_id": "doc1",
-                    "_rev": "rev1",
-                }
-            ]
-        }
-        data = await call_tool(
-            mcp, "sensors", {"site_name": "MAIN", "asset_id": "Chiller 1"}
-        )
-
-        assert data["total_sensors"] == 2
-        assert "Temp" in data["sensors"]
-        assert "Pressure" in data["sensors"]
-        # Internal fields must be excluded
-        assert "_id" not in data["sensors"]
-        assert "_rev" not in data["sensors"]
-
-    @requires_couchdb
-    @pytest.mark.anyio
-    async def test_success_integration(self):
-        data = await call_tool(
-            mcp, "sensors", {"site_name": "MAIN", "asset_id": "Chiller 6"}
-        )
-        assert "sensors" in data
-        assert len(data["sensors"]) > 0
-        assert any("Power" in s or "Efficiency" in s for s in data["sensors"])
-
-
-# ---------------------------------------------------------------------------
-# history
-# ---------------------------------------------------------------------------
-
-
-class TestHistory:
-    @pytest.mark.anyio
-    async def test_invalid_date_range(self):
-        data = await call_tool(
-            mcp,
-            "history",
-            {
-                "site_name": "MAIN",
-                "asset_id": "Chiller 6",
-                "start": "2020-06-01T00:00:00",
-                "final": "2020-05-01T00:00:00",
-            },
-        )
-        assert "error" in data
-        assert "start >= final" in data["error"]
-
-    @pytest.mark.anyio
-    async def test_malformed_date(self):
-        data = await call_tool(
-            mcp,
-            "history",
-            {"site_name": "MAIN", "asset_id": "Chiller 6", "start": "not-a-date"},
-        )
-        assert "error" in data
-
-    @pytest.mark.anyio
-    async def test_db_disconnected(self, no_db):
-        data = await call_tool(
-            mcp,
-            "history",
-            {
-                "site_name": "MAIN",
-                "asset_id": "Chiller 6",
-                "start": "2020-06-01T00:00:00",
-            },
-        )
-        assert "error" in data
-        assert "not connected" in data["error"].lower()
-
-    @pytest.mark.anyio
-    async def test_with_mock_db(self, mock_db):
-        mock_db.find.return_value = {
-            "docs": [
-                {"timestamp": "2024-01-01T00:00:00", "Temp": 20.0},
-                {"timestamp": "2024-01-01T00:15:00", "Temp": 21.0},
-            ]
-        }
-        data = await call_tool(
-            mcp,
-            "history",
-            {
-                "site_name": "MAIN",
-                "asset_id": "Chiller 1",
-                "start": "2024-01-01T00:00:00",
-            },
-        )
-
-        assert data["total_observations"] == 2
-        assert len(data["observations"]) == 2
-        assert data["observations"][0]["Temp"] == 20.0
-
-    @requires_couchdb
-    @pytest.mark.anyio
-    async def test_open_ended_integration(self):
-        data = await call_tool(
-            mcp,
-            "history",
-            {
-                "site_name": "MAIN",
-                "asset_id": "Chiller 6",
-                "start": "2020-06-01T00:00:00",
-            },
-        )
-        assert "observations" in data
-        assert "total_observations" in data
-
-    @requires_couchdb
-    @pytest.mark.anyio
-    async def test_bounded_range_integration(self):
-        data = await call_tool(
-            mcp,
-            "history",
-            {
-                "site_name": "MAIN",
-                "asset_id": "Chiller 6",
-                "start": "2020-06-01T00:00:00",
-                "final": "2020-06-01T01:00:00",
-            },
-        )
-        assert "observations" in data
-        for obs in data["observations"]:
-            assert obs["timestamp"] >= "2020-06-01T00:00:00"
-            assert obs["timestamp"] < "2020-06-01T01:00:00"


### PR DESCRIPTION
## Summary
- limit the IoT MCP server to registry discovery tools: `sites`, `asset_ids`, and `assets`
- add `sites()` using the registry-backed site discovery pattern from the pinned upstream IoT server
- make `asset_ids()` return only sorted `assetnum` values for a site
- make `assets()` return compact registry metadata, with optional `assettype` filtering
- improve MCP-visible docstrings using the FastMCP-style summary plus `Args` and successful-result `Returns` sections
- use backend-neutral registry database wording in IoT tool docs and tool errors
- remove `_id`, `doctype`, `iot_asset_id`, and `wo_assetnum` from `src/couchdb/scenarios_data/shared/iot/asset_profile_sample.json`
- update tests, docs, ToolUniverse/OpenCode examples, and legacy workflow messaging for the new IoT tool surface

## Tool Surface
- `sites()` -> `{"sites": [...]}`
- `asset_ids(site_name)` -> bare asset id list for the site
- `assets(site_name, assettype?)` -> asset metadata rows: `asset_id`, `description`, `assettype`, `vintage`, `n_sensors`

## Tests
- `.venv/bin/python -m pytest src/servers/iot/tests src/mcphub/tests` (13 passed, 5 skipped; registry integrations skipped locally)
- `jq empty src/couchdb/scenarios_data/shared/iot/asset_profile_sample.json`
- `.venv/bin/python -m py_compile src/servers/iot/main.py src/servers/iot/tests/test_tools.py src/mcphub/workflows.py src/mcphub/tests/test_workflows.py`
- MCP registry smoke check confirmed `['asset_ids', 'assets', 'sites']`
- MCP docstring smoke check confirmed FastMCP-style summary, `Args`, and successful-result `Returns` sections for the IoT tools