### PR TITLE
Add IoT asset detail and sensor lookup tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ AssetOpsBench is a **unified framework for developing, orchestrating, and evalua
 
 | MCP Servers | Important tools |
 |---|---|
-| **IoT** | `sites`, `asset_ids`, `get_asset_detail`, `assets`, `installed_sensors`, `measured_sensors` |
+| **IoT** | `sites`, `asset_ids`, `asset_detail`, `assets`, `find_assets_by_sensors`, `installed_sensors`, `measured_sensors` |
 | **FMSR** | `get_failure_modes`, `generate_failure_modes`, `add_failure_modes`, `generate_failure_mode_sensor_mapping` |
 | **TSFM** | `forecasting`, `timeseries_anomaly_detection` |
 | **WO** | `get_work_order_distribution`, `predict_next_work_order`, ... |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ AssetOpsBench is a **unified framework for developing, orchestrating, and evalua
 
 | MCP Servers | Important tools |
 |---|---|
-| **IoT** | `sites`, `asset_ids`, `assets`, `measured_sensors` |
+| **IoT** | `sites`, `asset_ids`, `assets`, `installed_sensors`, `measured_sensors` |
 | **FMSR** | `get_failure_modes`, `generate_failure_modes`, `add_failure_modes`, `generate_failure_mode_sensor_mapping` |
 | **TSFM** | `forecasting`, `timeseries_anomaly_detection` |
 | **WO** | `get_work_order_distribution`, `predict_next_work_order`, ... |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ AssetOpsBench is a **unified framework for developing, orchestrating, and evalua
 
 | MCP Servers | Important tools |
 |---|---|
-| **IoT** | `sites`, `asset_ids`, `assets` |
+| **IoT** | `sites`, `asset_ids`, `assets`, `measured_sensors` |
 | **FMSR** | `get_failure_modes`, `generate_failure_modes`, `add_failure_modes`, `generate_failure_mode_sensor_mapping` |
 | **TSFM** | `forecasting`, `timeseries_anomaly_detection` |
 | **WO** | `get_work_order_distribution`, `predict_next_work_order`, ... |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ AssetOpsBench is a **unified framework for developing, orchestrating, and evalua
 
 | MCP Servers | Important tools |
 |---|---|
-| **IoT** | `sites`, `asset_ids`, `assets`, `installed_sensors`, `measured_sensors` |
+| **IoT** | `sites`, `asset_ids`, `get_asset_detail`, `assets`, `installed_sensors`, `measured_sensors` |
 | **FMSR** | `get_failure_modes`, `generate_failure_modes`, `add_failure_modes`, `generate_failure_mode_sensor_mapping` |
 | **TSFM** | `forecasting`, `timeseries_anomaly_detection` |
 | **WO** | `get_work_order_distribution`, `predict_next_work_order`, ... |

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -16,9 +16,10 @@ Six FastMCP servers expose the AssetOpsBench domain logic. Each is a standalone 
 The IoT server reads from the asset **registry** (`ASSET_DBNAME`, default `asset`, loaded from
 `asset_profile_sample.json`) and IoT telemetry records (`IOT_DBNAME`, default `iot`). It exposes
 registry discovery tools while the broader IoT tool surface is being rebuilt: `sites()` for site
-names, `asset_ids()` for bare `assetnum` values, `assets()` for registry metadata with optional
-`assettype` filtering, `installed_sensors()` for registry sensor inventory, and
-`measured_sensors()` for telemetry fields observed in records.
+names, `asset_ids()` for bare `assetnum` values, `get_asset_detail()` for one asset's registry
+details, `assets()` for registry metadata with optional `assettype` filtering,
+`installed_sensors()` for registry sensor inventory, and `measured_sensors()` for telemetry fields
+observed in records.
 
 **Path:** `src/servers/iot/main.py`
 **Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `ASSET_DBNAME`, `IOT_DBNAME`)
@@ -37,6 +38,7 @@ Source file: `src/couchdb/scenarios_data/shared/iot/asset_profile_sample.json`.
 | ----------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | `sites`           | -                                          | List known site names from the asset registry, with a default fallback                                       |
 | `asset_ids`       | `site_name`                                | List bare `assetnum` values registered at a site                                                            |
+| `get_asset_detail` | `site_name`, `asset_id`                  | Return one asset's registry details, including `n_installed_sensors`                                         |
 | `installed_sensors` | `site_name`, `asset_id`                  | List sensor names installed on an asset according to the asset registry                                      |
 | `measured_sensors` | `site_name`, `asset_id`                   | List measured telemetry fields observed for an asset                                                         |
 | `assets`          | `site_name`, `assettype?`                  | List assets with metadata (assettype, description, vintage, installed sensor count), optionally filtered by assettype |

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -16,10 +16,10 @@ Six FastMCP servers expose the AssetOpsBench domain logic. Each is a standalone 
 The IoT server reads from the asset **registry** (`ASSET_DBNAME`, default `asset`, loaded from
 `asset_profile_sample.json`) and IoT telemetry records (`IOT_DBNAME`, default `iot`). It exposes
 registry discovery tools while the broader IoT tool surface is being rebuilt: `sites()` for site
-names, `asset_ids()` for bare `assetnum` values, `get_asset_detail()` for one asset's registry
+names, `asset_ids()` for bare `assetnum` values, `asset_detail()` for one asset's registry
 details, `assets()` for registry metadata with optional `assettype` filtering,
-`installed_sensors()` for registry sensor inventory, and `measured_sensors()` for telemetry fields
-observed in records.
+`find_assets_by_sensors()` to find assets by installed or measured sensors, `installed_sensors()`
+for registry sensor inventory, and `measured_sensors()` for telemetry fields observed in records.
 
 **Path:** `src/servers/iot/main.py`
 **Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `ASSET_DBNAME`, `IOT_DBNAME`)
@@ -38,10 +38,18 @@ Source file: `src/couchdb/scenarios_data/shared/iot/asset_profile_sample.json`.
 | ----------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | `sites`           | -                                          | List known site names from the asset registry, with a default fallback                                       |
 | `asset_ids`       | `site_name`                                | List bare `assetnum` values registered at a site                                                            |
-| `get_asset_detail` | `site_name`, `asset_id`                  | Return one asset's registry details, including `n_installed_sensors`                                         |
+| `asset_detail`    | `site_name`, `asset_id`                  | Return one asset's registry details, including `n_installed_sensors`                                         |
+| `find_assets_by_sensors` | `site_name`, `sensors`, `match?`, `substring?`, `source?` | Find assets at a site by installed or measured sensor names                                                  |
 | `installed_sensors` | `site_name`, `asset_id`                  | List sensor names installed on an asset according to the asset registry                                      |
 | `measured_sensors` | `site_name`, `asset_id`                   | List measured telemetry fields observed for an asset                                                         |
 | `assets`          | `site_name`, `assettype?`                  | List assets with metadata (assettype, description, vintage, installed sensor count), optionally filtered by assettype |
+
+`find_assets_by_sensors()` searches only assets registered at the requested site. `match="all"`
+requires every query sensor to match, while `match="any"` requires at least one. Set
+`substring=true` to perform case-insensitive substring matching instead of exact sensor-name
+matching. `source="installed"` searches the asset registry sensor inventory; `source="measured"`
+searches telemetry fields observed in IoT records. Duplicate query sensors are deduplicated in
+the response while preserving their first occurrence order.
 
 ## utilities — Utilities
 

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -17,7 +17,8 @@ The IoT server reads from the asset **registry** (`ASSET_DBNAME`, default `asset
 `asset_profile_sample.json`) and IoT telemetry records (`IOT_DBNAME`, default `iot`). It exposes
 registry discovery tools while the broader IoT tool surface is being rebuilt: `sites()` for site
 names, `asset_ids()` for bare `assetnum` values, `assets()` for registry metadata with optional
-`assettype` filtering, and `measured_sensors()` for telemetry fields observed in records.
+`assettype` filtering, `installed_sensors()` for registry sensor inventory, and
+`measured_sensors()` for telemetry fields observed in records.
 
 **Path:** `src/servers/iot/main.py`
 **Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `ASSET_DBNAME`, `IOT_DBNAME`)
@@ -36,6 +37,7 @@ Source file: `src/couchdb/scenarios_data/shared/iot/asset_profile_sample.json`.
 | ----------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | `sites`           | -                                          | List known site names from the asset registry, with a default fallback                                       |
 | `asset_ids`       | `site_name`                                | List bare `assetnum` values registered at a site                                                            |
+| `installed_sensors` | `site_name`, `asset_id`                  | List sensor names installed on an asset according to the asset registry                                      |
 | `measured_sensors` | `site_name`, `asset_id`                   | List measured telemetry fields observed for an asset                                                         |
 | `assets`          | `site_name`, `assettype?`                  | List assets with metadata (assettype, description, vintage, installed sensor count), optionally filtered by assettype |
 

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -11,15 +11,16 @@ Six FastMCP servers expose the AssetOpsBench domain logic. Each is a standalone 
 - [tsfm — Time Series Foundation Model](#tsfm--time-series-foundation-model)
 - [vibration — Vibration Diagnostics](#vibration--vibration-diagnostics)
 
-## iot — IoT Asset Registry
+## iot — IoT Asset Registry and Telemetry Records
 
 The IoT server reads from the asset **registry** (`ASSET_DBNAME`, default `asset`, loaded from
-`asset_profile_sample.json`). It exposes registry discovery tools while the broader IoT tool surface
-is being rebuilt: `sites()` for site names, `asset_ids()` for bare `assetnum` values, and `assets()`
-for registry metadata with optional `assettype` filtering.
+`asset_profile_sample.json`) and IoT telemetry records (`IOT_DBNAME`, default `iot`). It exposes
+registry discovery tools while the broader IoT tool surface is being rebuilt: `sites()` for site
+names, `asset_ids()` for bare `assetnum` values, `assets()` for registry metadata with optional
+`assettype` filtering, and `measured_sensors()` for telemetry fields observed in records.
 
 **Path:** `src/servers/iot/main.py`
-**Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `ASSET_DBNAME`)
+**Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `ASSET_DBNAME`, `IOT_DBNAME`)
 
 **Sample asset profiles shipped in the `asset` database** (loaded by `src/couchdb/init_data.py`):
 
@@ -35,6 +36,7 @@ Source file: `src/couchdb/scenarios_data/shared/iot/asset_profile_sample.json`.
 | ----------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | `sites`           | -                                          | List known site names from the asset registry, with a default fallback                                       |
 | `asset_ids`       | `site_name`                                | List bare `assetnum` values registered at a site                                                            |
+| `measured_sensors` | `site_name`, `asset_id`                   | List measured telemetry fields observed for an asset                                                         |
 | `assets`          | `site_name`, `assettype?`                  | List assets with metadata (assettype, description, vintage, installed sensor count), optionally filtered by assettype |
 
 ## utilities — Utilities

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -57,7 +57,7 @@ mcp = FastMCP(
 
 DEFAULT_SITES = ["MAIN"]
 PAGE_SIZE = 1000
-RESERVED_FIELDS = {"_id", "_rev", "asset_id", "timestamp"}
+RESERVED_FIELDS = {"_id", "_rev", "asset_id", "timestamp", "dataset", "type", "doctype"}
 
 
 class ErrorResult(BaseModel):
@@ -246,7 +246,7 @@ def measured_sensors(
         SensorsResult: Contains `site_name`, `asset_id`, `total_sensors`,
         `sensors`, and `message`. The `sensors` field is a sorted list of
         telemetry record fields observed for the asset, excluding structural
-        fields such as `asset_id` and `timestamp`.
+        fields such as `asset_id`, `timestamp`, and `dataset`.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 import couchdb3
 from dotenv import load_dotenv
@@ -19,7 +19,20 @@ logger = logging.getLogger("iot-mcp-server")
 COUCHDB_URL = os.environ.get("COUCHDB_URL")
 COUCHDB_USERNAME = os.environ.get("COUCHDB_USERNAME")
 COUCHDB_PASSWORD = os.environ.get("COUCHDB_PASSWORD")
+IOT_DBNAME = os.environ.get("IOT_DBNAME", "iot")
 ASSET_DBNAME = os.environ.get("ASSET_DBNAME", "asset")
+
+try:
+    db = couchdb3.Database(
+        IOT_DBNAME,
+        url=COUCHDB_URL,
+        user=COUCHDB_USERNAME,
+        password=COUCHDB_PASSWORD,
+    )
+    logger.info(f"Connected to IoT records database: {IOT_DBNAME}")
+except Exception as e:
+    logger.error(f"Failed to connect to IoT records database: {e}")
+    db = None
 
 try:
     asset_db = couchdb3.Database(
@@ -36,13 +49,15 @@ except Exception as e:
 mcp = FastMCP(
     "iot",
     instructions=(
-        "IoT asset registry tools. Use sites() to discover site names, asset_ids() for bare "
-        "assetnum values at a site, and assets() for registry metadata with optional "
-        "assettype filtering."
+        "IoT asset registry and telemetry record tools. Use sites() to discover site names, "
+        "asset_ids() for bare assetnum values at a site, assets() for registry metadata with "
+        "optional assettype filtering, and measured_sensors() for observed telemetry fields."
     ),
 )
 
 DEFAULT_SITES = ["MAIN"]
+PAGE_SIZE = 1000
+RESERVED_FIELDS = {"_id", "_rev", "asset_id", "timestamp"}
 
 
 class ErrorResult(BaseModel):
@@ -57,6 +72,14 @@ class AssetsResult(BaseModel):
     site_name: str
     total_assets: int
     assets: List[str]
+    message: str
+
+
+class SensorsResult(BaseModel):
+    site_name: str
+    asset_id: str
+    total_sensors: int
+    sensors: List[str]
     message: str
 
 
@@ -76,6 +99,58 @@ class AssetsWithMetadataResult(BaseModel):
 
 
 _registry_sites_cache: Optional[List[str]] = None
+_sensor_list_cache: Dict[str, List[str]] = {}
+
+
+def _iter_records(
+    selector: Dict[str, Any],
+    fields: Optional[List[str]] = None,
+    sort: Optional[List[Dict[str, str]]] = None,
+    page_size: int = PAGE_SIZE,
+) -> Iterator[Dict[str, Any]]:
+    """Yield telemetry records matching a selector across paged database results."""
+    if not db:
+        return
+    if sort is None:
+        sort = [{"asset_id": "asc"}, {"timestamp": "asc"}]
+    bookmark: Optional[str] = None
+    while True:
+        kwargs: Dict[str, Any] = {"limit": page_size, "sort": sort}
+        if fields is not None:
+            kwargs["fields"] = fields
+        if bookmark is not None:
+            kwargs["bookmark"] = bookmark
+        res = db.find(selector, **kwargs)
+        docs = res.get("docs", [])
+        if not docs:
+            break
+        for doc in docs:
+            yield doc
+        bookmark = res.get("bookmark")
+        if bookmark is None or len(docs) < page_size:
+            break
+
+
+def get_sensor_list(asset_id: str) -> List[str]:
+    """Return sorted telemetry field names observed across all records for an asset."""
+    if asset_id in _sensor_list_cache:
+        return _sensor_list_cache[asset_id]
+    if not db:
+        return []
+    try:
+        found = set()
+        seen = False
+        for doc in _iter_records({"asset_id": asset_id}):
+            seen = True
+            found.update(key for key in doc.keys() if key not in RESERVED_FIELDS)
+        if not seen:
+            return []
+        sensors = sorted(found)
+        _sensor_list_cache[asset_id] = sensors
+        return sensors
+    except Exception as e:
+        logger.error(f"get_sensor_list failed for asset_id {asset_id}: {e}")
+        return []
 
 
 def get_registry_sites() -> List[str]:
@@ -154,6 +229,44 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
     except Exception as e:
         logger.error(f"asset_ids failed: {e}")
         return ErrorResult(error=str(e))
+
+
+@mcp.tool(title="List Measured Sensors")
+def measured_sensors(
+    site_name: str, asset_id: str
+) -> Union[SensorsResult, ErrorResult]:
+    """List measured sensor fields for one asset at one site.
+
+    Args:
+        site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
+            discover valid site ids.
+        asset_id: Exact asset id from `asset_ids()`, such as `Chiller 6`.
+
+    Returns:
+        SensorsResult: Contains `site_name`, `asset_id`, `total_sensors`,
+        `sensors`, and `message`. The `sensors` field is a sorted list of
+        telemetry record fields observed for the asset, excluding structural
+        fields such as `asset_id` and `timestamp`.
+    """
+    if not _is_known_site(site_name):
+        return ErrorResult(error=f"unknown site {site_name}")
+    if not db:
+        return ErrorResult(error="IoT records database not connected")
+
+    sensor_list = get_sensor_list(asset_id)
+    if not sensor_list:
+        return ErrorResult(error=f"unknown asset_id {asset_id} or no sensors found")
+
+    return SensorsResult(
+        site_name=site_name,
+        asset_id=asset_id,
+        total_sensors=len(sensor_list),
+        sensors=sensor_list,
+        message=(
+            f"found {len(sensor_list)} sensors for asset_id {asset_id} "
+            f"and site_name {site_name}: {', '.join(sensor_list)}."
+        ),
+    )
 
 
 @mcp.tool(title="List Assets")

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -51,7 +51,8 @@ mcp = FastMCP(
     instructions=(
         "IoT asset registry and telemetry record tools. Use sites() to discover site names, "
         "asset_ids() for bare assetnum values at a site, assets() for registry metadata with "
-        "optional assettype filtering, and measured_sensors() for observed telemetry fields."
+        "optional assettype filtering, installed_sensors() for registry sensor inventory, "
+        "and measured_sensors() for observed telemetry fields."
     ),
 )
 
@@ -267,6 +268,50 @@ def measured_sensors(
             f"and site_name {site_name}: {', '.join(sensor_list)}."
         ),
     )
+
+
+@mcp.tool(title="List Installed Sensors")
+def installed_sensors(
+    site_name: str, asset_id: str
+) -> Union[SensorsResult, ErrorResult]:
+    """List installed sensor names for one asset from the asset registry.
+
+    Args:
+        site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
+            discover valid site ids.
+        asset_id: Exact asset id from `asset_ids()`, such as `Chiller 6`.
+
+    Returns:
+        SensorsResult: Contains `site_name`, `asset_id`, `total_sensors`,
+        `sensors`, and `message`. The `sensors` field is the registry
+        inventory for the asset, distinct from `measured_sensors()`, which
+        lists fields observed in IoT telemetry records.
+    """
+    if not _is_known_site(site_name):
+        return ErrorResult(error=f"unknown site {site_name}")
+    if not asset_db:
+        return ErrorResult(error="asset registry database not connected")
+
+    try:
+        res = asset_db.find(
+            {"siteid": site_name, "assetnum": asset_id},
+            fields=["assetnum", "sensors"],
+            limit=1,
+        )
+        docs = res.get("docs", [])
+        if not docs:
+            return ErrorResult(error=f"unknown asset_id {asset_id} at site {site_name}")
+        names = list(docs[0].get("sensors", []))
+        return SensorsResult(
+            site_name=site_name,
+            asset_id=asset_id,
+            total_sensors=len(names),
+            sensors=names,
+            message=f"{len(names)} sensors installed on {asset_id}: {', '.join(names)}.",
+        )
+    except Exception as e:
+        logger.error(f"installed_sensors failed: {e}")
+        return ErrorResult(error=str(e))
 
 
 @mcp.tool(title="List Assets")

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -50,9 +50,10 @@ mcp = FastMCP(
     "iot",
     instructions=(
         "IoT asset registry and telemetry record tools. Use sites() to discover site names, "
-        "asset_ids() for bare assetnum values at a site, assets() for registry metadata with "
-        "optional assettype filtering, installed_sensors() for registry sensor inventory, "
-        "and measured_sensors() for observed telemetry fields."
+        "asset_ids() for bare assetnum values at a site, get_asset_detail() for one asset's "
+        "registry details, assets() for registry metadata with optional assettype filtering, "
+        "installed_sensors() for registry sensor inventory, and measured_sensors() for "
+        "observed telemetry fields."
     ),
 )
 
@@ -81,6 +82,19 @@ class SensorsResult(BaseModel):
     asset_id: str
     total_sensors: int
     sensors: List[str]
+    message: str
+
+
+class AssetDetail(BaseModel):
+    site_name: str
+    asset_id: str
+    description: Optional[str]
+    assettype: Optional[str]
+    status: Optional[str]
+    location: Optional[str]
+    installdate: Optional[str]
+    vintage: Optional[str]
+    n_installed_sensors: int
     message: str
 
 
@@ -232,6 +246,79 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
         return ErrorResult(error=str(e))
 
 
+@mcp.tool(title="Get Asset Detail")
+def get_asset_detail(site_name: str, asset_id: str) -> Union[AssetDetail, ErrorResult]:
+    """Return registry details for one asset.
+
+    This tool reads the asset registry from `asset_db` (`ASSET_DBNAME`, default
+    `asset`) and returns nameplate fields for one asset record. Use
+    `installed_sensors()` when you only need the registry sensor inventory.
+
+    Args:
+        site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
+            discover valid site ids.
+        asset_id: Exact asset id from `asset_ids()`, such as `Chiller 6`.
+
+    Returns:
+        AssetDetail: Contains `site_name`, `asset_id`, `description`,
+        `assettype`, `status`, `location`, `installdate`, `vintage`,
+        `n_installed_sensors`, and `message`.
+    """
+    if not _is_known_site(site_name):
+        return ErrorResult(error=f"unknown site {site_name}")
+    if not asset_db:
+        return ErrorResult(error="asset registry database not connected")
+
+    try:
+        res = asset_db.find(
+            {"siteid": site_name, "assetnum": asset_id},
+            fields=[
+                "assetnum",
+                "description",
+                "assettype",
+                "status",
+                "location",
+                "installdate",
+                "vintage",
+                "sensors",
+            ],
+            limit=1,
+        )
+        docs = res.get("docs", [])
+        if not docs:
+            return ErrorResult(error=f"unknown asset_id {asset_id} at site {site_name}")
+
+        doc = docs[0]
+        sensors = list(doc.get("sensors") or [])
+        n_installed_sensors = len(sensors)
+        assettype = doc.get("assettype")
+        vintage = doc.get("vintage")
+        location = doc.get("location")
+
+        parts = [f"asset {asset_id} is a {assettype or 'asset'}"]
+        if vintage:
+            parts.append(f" ({vintage} vintage)")
+        if location:
+            parts.append(f" at {location}")
+        parts.append(f" with {n_installed_sensors} installed sensors.")
+
+        return AssetDetail(
+            site_name=site_name,
+            asset_id=doc.get("assetnum", asset_id),
+            description=doc.get("description"),
+            assettype=assettype,
+            status=doc.get("status"),
+            location=location,
+            installdate=doc.get("installdate"),
+            vintage=vintage,
+            n_installed_sensors=n_installed_sensors,
+            message="".join(parts),
+        )
+    except Exception as e:
+        logger.error(f"get_asset_detail failed: {e}")
+        return ErrorResult(error=str(e))
+
+
 @mcp.tool(title="List Measured Sensors")
 def measured_sensors(
     site_name: str, asset_id: str
@@ -310,7 +397,7 @@ def installed_sensors(
         docs = res.get("docs", [])
         if not docs:
             return ErrorResult(error=f"unknown asset_id {asset_id} at site {site_name}")
-        names = list(docs[0].get("sensors", []))
+        names = list(docs[0].get("sensors") or [])
         return SensorsResult(
             site_name=site_name,
             asset_id=asset_id,
@@ -361,7 +448,7 @@ def assets(
                     assettype=doc.get("assettype"),
                     description=doc.get("description"),
                     vintage=doc.get("vintage"),
-                    n_sensors=len(doc.get("sensors", [])),
+                    n_sensors=len(doc.get("sensors") or []),
                 )
                 for doc in res["docs"]
             ),

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -236,7 +236,12 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
 def measured_sensors(
     site_name: str, asset_id: str
 ) -> Union[SensorsResult, ErrorResult]:
-    """List measured sensor fields for one asset at one site.
+    """List telemetry fields actually measured for one asset.
+
+    This tool reads IoT records from `iot_db` (`IOT_DBNAME`, default `iot`).
+    It scans records matching `asset_id` and returns the union of observed
+    measurement fields. Use `installed_sensors()` instead when you need the
+    asset registry inventory.
 
     Args:
         site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
@@ -246,8 +251,8 @@ def measured_sensors(
     Returns:
         SensorsResult: Contains `site_name`, `asset_id`, `total_sensors`,
         `sensors`, and `message`. The `sensors` field is a sorted list of
-        telemetry record fields observed for the asset, excluding structural
-        fields such as `asset_id`, `timestamp`, and `dataset`.
+        observed telemetry fields, excluding record metadata such as `_id`,
+        `_rev`, `asset_id`, `timestamp`, `dataset`, `type`, and `doctype`.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")
@@ -274,7 +279,12 @@ def measured_sensors(
 def installed_sensors(
     site_name: str, asset_id: str
 ) -> Union[SensorsResult, ErrorResult]:
-    """List installed sensor names for one asset from the asset registry.
+    """List sensor names installed on one asset according to the registry.
+
+    This tool reads the asset registry from `asset_db` (`ASSET_DBNAME`, default
+    `asset`) and returns the asset record's `sensors` inventory. Use
+    `measured_sensors()` instead when you need fields actually observed in IoT
+    telemetry records.
 
     Args:
         site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
@@ -283,9 +293,8 @@ def installed_sensors(
 
     Returns:
         SensorsResult: Contains `site_name`, `asset_id`, `total_sensors`,
-        `sensors`, and `message`. The `sensors` field is the registry
-        inventory for the asset, distinct from `measured_sensors()`, which
-        lists fields observed in IoT telemetry records.
+        `sensors`, and `message`. The `sensors` field preserves the registry
+        sensor inventory order from the asset record.
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -50,8 +50,9 @@ mcp = FastMCP(
     "iot",
     instructions=(
         "IoT asset registry and telemetry record tools. Use sites() to discover site names, "
-        "asset_ids() for bare assetnum values at a site, get_asset_detail() for one asset's "
+        "asset_ids() for bare assetnum values at a site, asset_detail() for one asset's "
         "registry details, assets() for registry metadata with optional assettype filtering, "
+        "find_assets_by_sensors() to find assets by installed or measured sensors, "
         "installed_sensors() for registry sensor inventory, and measured_sensors() for "
         "observed telemetry fields."
     ),
@@ -110,6 +111,21 @@ class AssetsWithMetadataResult(BaseModel):
     site_name: str
     total_assets: int
     assets: List[AssetSummary]
+    message: str
+
+
+class AssetSensorMatch(BaseModel):
+    asset_id: str
+    matched_sensors: List[str]
+
+
+class FindAssetsResult(BaseModel):
+    site_name: str
+    query_sensors: List[str]
+    match: str
+    source: str
+    total_assets: int
+    assets: List[AssetSensorMatch]
     message: str
 
 
@@ -199,6 +215,38 @@ def _is_known_site(site_name: str) -> bool:
     return site_name in known_sites()
 
 
+def _site_asset_ids(site_name: str) -> List[str]:
+    """Return asset ids registered at a site."""
+    if not asset_db:
+        return []
+    try:
+        res = asset_db.find(
+            {"siteid": site_name},
+            fields=["assetnum"],
+            limit=100000,
+        )
+        return sorted(doc["assetnum"] for doc in res["docs"])
+    except Exception as e:
+        logger.error(f"_site_asset_ids failed: {e}")
+        return []
+
+
+def _installed_sensors(asset_id: str, site_name: Optional[str] = None) -> List[str]:
+    """Return registry sensor names installed on an asset."""
+    if not asset_db:
+        return []
+    try:
+        selector: Dict[str, Any] = {"assetnum": asset_id}
+        if site_name is not None:
+            selector["siteid"] = site_name
+        res = asset_db.find(selector, fields=["sensors"], limit=1)
+        docs = res.get("docs", [])
+        return list(docs[0].get("sensors") or []) if docs else []
+    except Exception as e:
+        logger.error(f"_installed_sensors failed for asset_id {asset_id}: {e}")
+        return []
+
+
 @mcp.tool(title="List Sites")
 def sites() -> SitesResult:
     """List known site names from the asset registry.
@@ -247,7 +295,7 @@ def asset_ids(site_name: str) -> Union[AssetsResult, ErrorResult]:
 
 
 @mcp.tool(title="Get Asset Detail")
-def get_asset_detail(site_name: str, asset_id: str) -> Union[AssetDetail, ErrorResult]:
+def asset_detail(site_name: str, asset_id: str) -> Union[AssetDetail, ErrorResult]:
     """Return registry details for one asset.
 
     This tool reads the asset registry from `asset_db` (`ASSET_DBNAME`, default
@@ -315,7 +363,7 @@ def get_asset_detail(site_name: str, asset_id: str) -> Union[AssetDetail, ErrorR
             message="".join(parts),
         )
     except Exception as e:
-        logger.error(f"get_asset_detail failed: {e}")
+        logger.error(f"asset_detail failed: {e}")
         return ErrorResult(error=str(e))
 
 
@@ -465,6 +513,102 @@ def assets(
     except Exception as e:
         logger.error(f"assets failed: {e}")
         return ErrorResult(error=str(e))
+
+
+@mcp.tool(title="Find Assets By Sensors")
+def find_assets_by_sensors(
+    site_name: str,
+    sensors: List[str],
+    match: str = "all",
+    substring: bool = False,
+    source: str = "measured",
+) -> Union[FindAssetsResult, ErrorResult]:
+    """Return assets at a site that match the requested sensor names.
+
+    The search is limited to assets registered at `site_name`. Duplicate query
+    sensors are ignored while preserving the first occurrence order.
+
+    Args:
+        site_name: Exact site id to query, such as `MAIN`. Use `sites()` to
+            discover valid site ids.
+        sensors: One or more sensor names or, when `substring` is true, sensor
+            name fragments to search for.
+        match: `all` requires every listed sensor; `any` requires at least one.
+        substring: If true, match sensor names case-insensitively by substring.
+        source: `measured` checks telemetry fields; `installed` checks the
+            asset registry inventory.
+
+    Returns:
+        FindAssetsResult: Contains the deduplicated query sensors, matching
+        asset ids, and the concrete sensor names that matched each asset.
+    """
+    if not _is_known_site(site_name):
+        return ErrorResult(error=f"unknown site {site_name}")
+    if match not in ("all", "any"):
+        return ErrorResult(error="match must be 'all' or 'any'")
+    if source not in ("measured", "installed"):
+        return ErrorResult(error="source must be 'measured' or 'installed'")
+    if not sensors:
+        return ErrorResult(error="provide at least one sensor name")
+    if not asset_db:
+        return ErrorResult(error="asset registry database not connected")
+    if source == "measured" and not iot_db:
+        return ErrorResult(error="IoT records database not connected")
+
+    query_sensors = list(dict.fromkeys(sensors))
+    matches: List[AssetSensorMatch] = []
+    for asset_id in _site_asset_ids(site_name):
+        available = (
+            get_sensor_list(asset_id)
+            if source == "measured"
+            else _installed_sensors(asset_id, site_name)
+        )
+
+        def _hits(sensor_name: str) -> List[str]:
+            if substring:
+                sensor_name_lower = sensor_name.lower()
+                return [
+                    available_sensor
+                    for available_sensor in available
+                    if sensor_name_lower in available_sensor.lower()
+                ]
+            return [
+                available_sensor
+                for available_sensor in available
+                if available_sensor == sensor_name
+            ]
+
+        per_query = {sensor_name: _hits(sensor_name) for sensor_name in query_sensors}
+        satisfied = [
+            sensor_name for sensor_name, hits in per_query.items() if hits
+        ]
+        ok = (
+            len(satisfied) == len(query_sensors)
+            if match == "all"
+            else len(satisfied) > 0
+        )
+        if ok:
+            matched = sorted(
+                {
+                    matched_sensor
+                    for hits in per_query.values()
+                    for matched_sensor in hits
+                }
+            )
+            matches.append(
+                AssetSensorMatch(asset_id=asset_id, matched_sensors=matched)
+            )
+
+    return FindAssetsResult(
+        site_name=site_name,
+        query_sensors=query_sensors,
+        match=match,
+        source=source,
+        total_assets=len(matches),
+        assets=matches,
+        message=f"{len(matches)} asset(s) at {site_name} match {query_sensors} "
+        f"(match={match}, substring={substring}, source={source}).",
+    )
 
 
 def main():

--- a/src/servers/iot/main.py
+++ b/src/servers/iot/main.py
@@ -23,7 +23,7 @@ IOT_DBNAME = os.environ.get("IOT_DBNAME", "iot")
 ASSET_DBNAME = os.environ.get("ASSET_DBNAME", "asset")
 
 try:
-    db = couchdb3.Database(
+    iot_db = couchdb3.Database(
         IOT_DBNAME,
         url=COUCHDB_URL,
         user=COUCHDB_USERNAME,
@@ -32,7 +32,7 @@ try:
     logger.info(f"Connected to IoT records database: {IOT_DBNAME}")
 except Exception as e:
     logger.error(f"Failed to connect to IoT records database: {e}")
-    db = None
+    iot_db = None
 
 try:
     asset_db = couchdb3.Database(
@@ -110,7 +110,7 @@ def _iter_records(
     page_size: int = PAGE_SIZE,
 ) -> Iterator[Dict[str, Any]]:
     """Yield telemetry records matching a selector across paged database results."""
-    if not db:
+    if not iot_db:
         return
     if sort is None:
         sort = [{"asset_id": "asc"}, {"timestamp": "asc"}]
@@ -121,7 +121,7 @@ def _iter_records(
             kwargs["fields"] = fields
         if bookmark is not None:
             kwargs["bookmark"] = bookmark
-        res = db.find(selector, **kwargs)
+        res = iot_db.find(selector, **kwargs)
         docs = res.get("docs", [])
         if not docs:
             break
@@ -136,7 +136,7 @@ def get_sensor_list(asset_id: str) -> List[str]:
     """Return sorted telemetry field names observed across all records for an asset."""
     if asset_id in _sensor_list_cache:
         return _sensor_list_cache[asset_id]
-    if not db:
+    if not iot_db:
         return []
     try:
         found = set()
@@ -251,7 +251,7 @@ def measured_sensors(
     """
     if not _is_known_site(site_name):
         return ErrorResult(error=f"unknown site {site_name}")
-    if not db:
+    if not iot_db:
         return ErrorResult(error="IoT records database not connected")
 
     sensor_list = get_sensor_list(asset_id)

--- a/src/servers/iot/tests/conftest.py
+++ b/src/servers/iot/tests/conftest.py
@@ -40,13 +40,13 @@ def _iot_data_reachable() -> bool:
 
         username = os.environ.get("COUCHDB_USERNAME")
         password = os.environ.get("COUCHDB_PASSWORD")
-        db = couchdb3.Database(
+        iot_db = couchdb3.Database(
             os.environ.get("IOT_DBNAME", "iot"),
             url=url,
             user=username,
             password=password,
         )
-        records = db.find({"asset_id": "Chiller 6"}, limit=1)["docs"]
+        records = iot_db.find({"asset_id": "Chiller 6"}, limit=1)["docs"]
         return bool(records)
     except Exception:
         return False
@@ -82,8 +82,8 @@ def mock_asset_db():
 
 @pytest.fixture
 def mock_iot_db():
-    """Patch the module-level telemetry records `db` object in main with a mock."""
-    with patch("servers.iot.main.db") as mock:
+    """Patch the module-level telemetry records `iot_db` object in main with a mock."""
+    with patch("servers.iot.main.iot_db") as mock:
         yield mock
 
 
@@ -96,8 +96,8 @@ def no_asset_db():
 
 @pytest.fixture
 def no_iot_db():
-    """Patch the module-level telemetry records `db` to None."""
-    with patch("servers.iot.main.db", None):
+    """Patch the module-level telemetry records `iot_db` to None."""
+    with patch("servers.iot.main.iot_db", None):
         yield
 
 

--- a/src/servers/iot/tests/conftest.py
+++ b/src/servers/iot/tests/conftest.py
@@ -31,11 +31,41 @@ def _couchdb_reachable() -> bool:
         return False
 
 
+def _iot_data_reachable() -> bool:
+    url = os.environ.get("COUCHDB_URL")
+    if not url:
+        return False
+    try:
+        import couchdb3
+
+        username = os.environ.get("COUCHDB_USERNAME")
+        password = os.environ.get("COUCHDB_PASSWORD")
+        db = couchdb3.Database(
+            os.environ.get("IOT_DBNAME", "iot"),
+            url=url,
+            user=username,
+            password=password,
+        )
+        records = db.find({"asset_id": "Chiller 6"}, limit=1)["docs"]
+        return bool(records)
+    except Exception:
+        return False
+
+
 requires_couchdb = pytest.mark.skipif(
     not _couchdb_reachable(),
     reason=(
         "CouchDB sample asset registry not available "
         "(set COUCHDB_URL and load the Chiller 6 asset profile)"
+    ),
+)
+
+
+requires_iot_db = pytest.mark.skipif(
+    not _iot_data_reachable(),
+    reason=(
+        "IoT sample records database not available "
+        "(set COUCHDB_URL and load the Chiller 6 telemetry records)"
     ),
 )
 
@@ -51,9 +81,23 @@ def mock_asset_db():
 
 
 @pytest.fixture
+def mock_iot_db():
+    """Patch the module-level telemetry records `db` object in main with a mock."""
+    with patch("servers.iot.main.db") as mock:
+        yield mock
+
+
+@pytest.fixture
 def no_asset_db():
-    """Patch the module-level `asset_db` to None (simulate disconnected CouchDB)."""
+    """Patch the module-level `asset_db` to None (simulate disconnected database)."""
     with patch("servers.iot.main.asset_db", None):
+        yield
+
+
+@pytest.fixture
+def no_iot_db():
+    """Patch the module-level telemetry records `db` to None."""
+    with patch("servers.iot.main.db", None):
         yield
 
 
@@ -63,8 +107,10 @@ def clear_iot_caches():
     import servers.iot.main as iot_main
 
     iot_main._registry_sites_cache = None
+    iot_main._sensor_list_cache = {}
     yield
     iot_main._registry_sites_cache = None
+    iot_main._sensor_list_cache = {}
 
 
 async def call_tool(mcp_instance, tool_name: str, args: dict) -> dict:

--- a/src/servers/iot/tests/test_tools.py
+++ b/src/servers/iot/tests/test_tools.py
@@ -13,6 +13,7 @@ class TestToolRegistration:
         assert sorted(tool.name for tool in tools) == [
             "asset_ids",
             "assets",
+            "installed_sensors",
             "measured_sensors",
             "sites",
         ]
@@ -164,6 +165,92 @@ class TestMeasuredSensors:
         )
         assert "sensors" in data
         assert "Chiller 6 Supply Temperature" in data["sensors"]
+        assert data["total_sensors"] > 0
+
+
+class TestInstalledSensors:
+    @pytest.mark.anyio
+    async def test_invalid_site(self):
+        data = await call_tool(
+            mcp, "installed_sensors", {"site_name": "INVALID", "asset_id": "Pump-1"}
+        )
+        assert "error" in data
+        assert "unknown site" in data["error"]
+
+    @pytest.mark.anyio
+    async def test_with_mock_asset_db(self, mock_asset_db):
+        mock_asset_db.find.side_effect = [
+            {"docs": [{"siteid": "MAIN"}]},
+            {
+                "docs": [
+                    {
+                        "assetnum": "Pump-1",
+                        "sensors": ["Registry Pressure", "Registry Temperature"],
+                    }
+                ]
+            },
+        ]
+
+        data = await call_tool(
+            mcp, "installed_sensors", {"site_name": "MAIN", "asset_id": "Pump-1"}
+        )
+
+        assert data["site_name"] == "MAIN"
+        assert data["asset_id"] == "Pump-1"
+        assert data["total_sensors"] == 2
+        assert data["sensors"] == ["Registry Pressure", "Registry Temperature"]
+        mock_asset_db.find.assert_called_with(
+            {"siteid": "MAIN", "assetnum": "Pump-1"},
+            fields=["assetnum", "sensors"],
+            limit=1,
+        )
+
+    @pytest.mark.anyio
+    async def test_reads_asset_registry_not_iot_db(self, mock_asset_db, mock_iot_db):
+        mock_asset_db.find.side_effect = [
+            {"docs": [{"siteid": "MAIN"}]},
+            {
+                "docs": [
+                    {
+                        "assetnum": "Pump-1",
+                        "sensors": ["Registry Sensor"],
+                    }
+                ]
+            },
+        ]
+        mock_iot_db.find.return_value = {
+            "docs": [
+                {
+                    "asset_id": "Pump-1",
+                    "timestamp": "2024-01-01T00:00:00",
+                    "Telemetry Sensor": 42,
+                }
+            ]
+        }
+
+        data = await call_tool(
+            mcp, "installed_sensors", {"site_name": "MAIN", "asset_id": "Pump-1"}
+        )
+
+        assert data["sensors"] == ["Registry Sensor"]
+        mock_iot_db.find.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_db_disconnected(self, no_asset_db):
+        data = await call_tool(
+            mcp, "installed_sensors", {"site_name": "MAIN", "asset_id": "Pump-1"}
+        )
+        assert "error" in data
+        assert "not connected" in data["error"].lower()
+
+    @requires_couchdb
+    @pytest.mark.anyio
+    async def test_discovery_integration(self):
+        data = await call_tool(
+            mcp, "installed_sensors", {"site_name": "MAIN", "asset_id": "Chiller 6"}
+        )
+        assert "sensors" in data
+        assert "Chiller 6 Oil Pressure" in data["sensors"]
         assert data["total_sensors"] > 0
 
 

--- a/src/servers/iot/tests/test_tools.py
+++ b/src/servers/iot/tests/test_tools.py
@@ -114,6 +114,40 @@ class TestMeasuredSensors:
         assert data["sensors"] == ["Pressure", "Temperature"]
 
     @pytest.mark.anyio
+    async def test_reads_iot_db_not_asset_registry(self, mock_asset_db, mock_iot_db):
+        mock_asset_db.find.return_value = {
+            "docs": [
+                {
+                    "siteid": "MAIN",
+                    "assetnum": "Pump-1",
+                    "sensors": ["Registry Sensor"],
+                }
+            ]
+        }
+        mock_iot_db.find.return_value = {
+            "docs": [
+                {
+                    "asset_id": "Pump-1",
+                    "timestamp": "2024-01-01T00:00:00",
+                    "Telemetry Sensor": 42,
+                }
+            ]
+        }
+
+        data = await call_tool(
+            mcp, "measured_sensors", {"site_name": "MAIN", "asset_id": "Pump-1"}
+        )
+
+        assert data["sensors"] == ["Telemetry Sensor"]
+        assert mock_asset_db.find.call_count == 1
+        mock_asset_db.find.assert_called_once_with(
+            {"siteid": {"$exists": True}},
+            fields=["siteid"],
+            limit=100000,
+        )
+        mock_iot_db.find.assert_called_once()
+
+    @pytest.mark.anyio
     async def test_db_disconnected(self, mock_asset_db, no_iot_db):
         mock_asset_db.find.return_value = {"docs": [{"siteid": "MAIN"}]}
         data = await call_tool(

--- a/src/servers/iot/tests/test_tools.py
+++ b/src/servers/iot/tests/test_tools.py
@@ -11,9 +11,10 @@ class TestToolRegistration:
     async def test_registry_tools_are_registered(self):
         tools = await mcp.list_tools()
         assert sorted(tool.name for tool in tools) == [
+            "asset_detail",
             "asset_ids",
             "assets",
-            "get_asset_detail",
+            "find_assets_by_sensors",
             "installed_sensors",
             "measured_sensors",
             "sites",
@@ -74,11 +75,11 @@ class TestAssetIds:
         assert data["total_assets"] > 0
 
 
-class TestGetAssetDetail:
+class TestAssetDetail:
     @pytest.mark.anyio
     async def test_invalid_site(self):
         data = await call_tool(
-            mcp, "get_asset_detail", {"site_name": "INVALID", "asset_id": "Pump-1"}
+            mcp, "asset_detail", {"site_name": "INVALID", "asset_id": "Pump-1"}
         )
         assert "error" in data
         assert "unknown site" in data["error"]
@@ -104,7 +105,7 @@ class TestGetAssetDetail:
         ]
 
         data = await call_tool(
-            mcp, "get_asset_detail", {"site_name": "MAIN", "asset_id": "Pump-1"}
+            mcp, "asset_detail", {"site_name": "MAIN", "asset_id": "Pump-1"}
         )
 
         assert data == {
@@ -150,7 +151,7 @@ class TestGetAssetDetail:
         }
 
         data = await call_tool(
-            mcp, "get_asset_detail", {"site_name": "MAIN", "asset_id": "Pump-1"}
+            mcp, "asset_detail", {"site_name": "MAIN", "asset_id": "Pump-1"}
         )
 
         assert data["description"] == "Registry pump"
@@ -160,7 +161,7 @@ class TestGetAssetDetail:
     @pytest.mark.anyio
     async def test_db_disconnected(self, no_asset_db):
         data = await call_tool(
-            mcp, "get_asset_detail", {"site_name": "MAIN", "asset_id": "Pump-1"}
+            mcp, "asset_detail", {"site_name": "MAIN", "asset_id": "Pump-1"}
         )
         assert "error" in data
         assert "not connected" in data["error"].lower()
@@ -169,7 +170,7 @@ class TestGetAssetDetail:
     @pytest.mark.anyio
     async def test_discovery_integration(self):
         data = await call_tool(
-            mcp, "get_asset_detail", {"site_name": "MAIN", "asset_id": "Chiller 6"}
+            mcp, "asset_detail", {"site_name": "MAIN", "asset_id": "Chiller 6"}
         )
         assert data["asset_id"] == "Chiller 6"
         assert data["assettype"] == "CHILLER"
@@ -356,6 +357,120 @@ class TestInstalledSensors:
         assert "sensors" in data
         assert "Chiller 6 Oil Pressure" in data["sensors"]
         assert data["total_sensors"] > 0
+
+
+class TestFindAssetsBySensors:
+    @pytest.mark.anyio
+    async def test_invalid_site(self):
+        data = await call_tool(
+            mcp,
+            "find_assets_by_sensors",
+            {"site_name": "INVALID", "sensors": ["Pressure"]},
+        )
+        assert "error" in data
+        assert "unknown site" in data["error"]
+
+    @pytest.mark.anyio
+    async def test_installed_source_exact_match(self, mock_asset_db):
+        mock_asset_db.find.side_effect = [
+            {"docs": [{"siteid": "MAIN"}]},
+            {"docs": [{"assetnum": "Fan-2"}, {"assetnum": "Pump-1"}]},
+            {"docs": [{"sensors": ["Temperature"]}]},
+            {"docs": [{"sensors": ["Pressure", "Temperature"]}]},
+        ]
+
+        data = await call_tool(
+            mcp,
+            "find_assets_by_sensors",
+            {
+                "site_name": "MAIN",
+                "sensors": ["Pressure"],
+                "source": "installed",
+            },
+        )
+
+        assert data["site_name"] == "MAIN"
+        assert data["query_sensors"] == ["Pressure"]
+        assert data["match"] == "all"
+        assert data["source"] == "installed"
+        assert data["total_assets"] == 1
+        assert data["assets"] == [
+            {"asset_id": "Pump-1", "matched_sensors": ["Pressure"]}
+        ]
+
+    @pytest.mark.anyio
+    async def test_deduplicates_query_sensors_for_all_match(self, mock_asset_db):
+        mock_asset_db.find.side_effect = [
+            {"docs": [{"siteid": "MAIN"}]},
+            {"docs": [{"assetnum": "Pump-1"}]},
+            {"docs": [{"sensors": ["Pressure", "Temperature"]}]},
+        ]
+
+        data = await call_tool(
+            mcp,
+            "find_assets_by_sensors",
+            {
+                "site_name": "MAIN",
+                "sensors": ["Pressure", "Pressure"],
+                "source": "installed",
+            },
+        )
+
+        assert data["query_sensors"] == ["Pressure"]
+        assert data["total_assets"] == 1
+        assert data["assets"] == [
+            {"asset_id": "Pump-1", "matched_sensors": ["Pressure"]}
+        ]
+
+    @pytest.mark.anyio
+    async def test_measured_source_substring_match(self, mock_asset_db, mock_iot_db):
+        mock_asset_db.find.side_effect = [
+            {"docs": [{"siteid": "MAIN"}]},
+            {"docs": [{"assetnum": "Compressor-1"}, {"assetnum": "Pump-1"}]},
+        ]
+
+        def find_records(selector, **kwargs):
+            asset_id = selector["asset_id"]
+            if asset_id == "Compressor-1":
+                return {
+                    "docs": [
+                        {
+                            "asset_id": "Compressor-1",
+                            "timestamp": "2024-01-01T00:00:00",
+                            "Oil Pressure": 12,
+                        }
+                    ]
+                }
+            if asset_id == "Pump-1":
+                return {
+                    "docs": [
+                        {
+                            "asset_id": "Pump-1",
+                            "timestamp": "2024-01-01T00:00:00",
+                            "Discharge Pressure": 42,
+                            "Flow": 4,
+                        }
+                    ]
+                }
+            return {"docs": []}
+
+        mock_iot_db.find.side_effect = find_records
+
+        data = await call_tool(
+            mcp,
+            "find_assets_by_sensors",
+            {
+                "site_name": "MAIN",
+                "sensors": ["pressure"],
+                "substring": True,
+            },
+        )
+
+        assert data["total_assets"] == 2
+        assert data["assets"] == [
+            {"asset_id": "Compressor-1", "matched_sensors": ["Oil Pressure"]},
+            {"asset_id": "Pump-1", "matched_sensors": ["Discharge Pressure"]},
+        ]
 
 
 class TestAssets:

--- a/src/servers/iot/tests/test_tools.py
+++ b/src/servers/iot/tests/test_tools.py
@@ -3,14 +3,19 @@
 import pytest
 
 from servers.iot.main import mcp
-from .conftest import call_tool, requires_couchdb
+from .conftest import call_tool, requires_couchdb, requires_iot_db
 
 
 class TestToolRegistration:
     @pytest.mark.anyio
     async def test_registry_tools_are_registered(self):
         tools = await mcp.list_tools()
-        assert sorted(tool.name for tool in tools) == ["asset_ids", "assets", "sites"]
+        assert sorted(tool.name for tool in tools) == [
+            "asset_ids",
+            "assets",
+            "measured_sensors",
+            "sites",
+        ]
 
 
 class TestSites:
@@ -65,6 +70,65 @@ class TestAssetIds:
         assert "assets" in data
         assert "Chiller 6" in data["assets"]
         assert data["total_assets"] > 0
+
+
+class TestMeasuredSensors:
+    @pytest.mark.anyio
+    async def test_invalid_site(self):
+        data = await call_tool(
+            mcp, "measured_sensors", {"site_name": "INVALID", "asset_id": "Pump-1"}
+        )
+        assert "error" in data
+        assert "unknown site" in data["error"]
+
+    @pytest.mark.anyio
+    async def test_with_mock_iot_db(self, mock_asset_db, mock_iot_db):
+        mock_asset_db.find.return_value = {"docs": [{"siteid": "MAIN"}]}
+        mock_iot_db.find.return_value = {
+            "docs": [
+                {
+                    "_id": "iot:Pump-1:1",
+                    "_rev": "1-abc",
+                    "asset_id": "Pump-1",
+                    "timestamp": "2024-01-01T00:00:00",
+                    "Pressure": 10,
+                },
+                {
+                    "asset_id": "Pump-1",
+                    "timestamp": "2024-01-01T00:01:00",
+                    "Temperature": 30,
+                    "Pressure": 11,
+                },
+            ]
+        }
+
+        data = await call_tool(
+            mcp, "measured_sensors", {"site_name": "MAIN", "asset_id": "Pump-1"}
+        )
+
+        assert data["site_name"] == "MAIN"
+        assert data["asset_id"] == "Pump-1"
+        assert data["total_sensors"] == 2
+        assert data["sensors"] == ["Pressure", "Temperature"]
+
+    @pytest.mark.anyio
+    async def test_db_disconnected(self, mock_asset_db, no_iot_db):
+        mock_asset_db.find.return_value = {"docs": [{"siteid": "MAIN"}]}
+        data = await call_tool(
+            mcp, "measured_sensors", {"site_name": "MAIN", "asset_id": "Pump-1"}
+        )
+        assert "error" in data
+        assert "not connected" in data["error"].lower()
+
+    @requires_iot_db
+    @pytest.mark.anyio
+    async def test_discovery_integration(self):
+        data = await call_tool(
+            mcp, "measured_sensors", {"site_name": "MAIN", "asset_id": "Chiller 6"}
+        )
+        assert "sensors" in data
+        assert "Chiller 6 Supply Temperature" in data["sensors"]
+        assert data["total_sensors"] > 0
 
 
 class TestAssets:

--- a/src/servers/iot/tests/test_tools.py
+++ b/src/servers/iot/tests/test_tools.py
@@ -13,6 +13,7 @@ class TestToolRegistration:
         assert sorted(tool.name for tool in tools) == [
             "asset_ids",
             "assets",
+            "get_asset_detail",
             "installed_sensors",
             "measured_sensors",
             "sites",
@@ -71,6 +72,109 @@ class TestAssetIds:
         assert "assets" in data
         assert "Chiller 6" in data["assets"]
         assert data["total_assets"] > 0
+
+
+class TestGetAssetDetail:
+    @pytest.mark.anyio
+    async def test_invalid_site(self):
+        data = await call_tool(
+            mcp, "get_asset_detail", {"site_name": "INVALID", "asset_id": "Pump-1"}
+        )
+        assert "error" in data
+        assert "unknown site" in data["error"]
+
+    @pytest.mark.anyio
+    async def test_with_mock_asset_db(self, mock_asset_db):
+        mock_asset_db.find.side_effect = [
+            {"docs": [{"siteid": "MAIN"}]},
+            {
+                "docs": [
+                    {
+                        "assetnum": "Pump-1",
+                        "description": "Main pump",
+                        "assettype": "PUMP",
+                        "status": "OPERATING",
+                        "location": "PUMP-HOUSE",
+                        "installdate": "2024-01-01",
+                        "vintage": "new",
+                        "sensors": ["Pressure", "Temperature"],
+                    }
+                ]
+            },
+        ]
+
+        data = await call_tool(
+            mcp, "get_asset_detail", {"site_name": "MAIN", "asset_id": "Pump-1"}
+        )
+
+        assert data == {
+            "site_name": "MAIN",
+            "asset_id": "Pump-1",
+            "description": "Main pump",
+            "assettype": "PUMP",
+            "status": "OPERATING",
+            "location": "PUMP-HOUSE",
+            "installdate": "2024-01-01",
+            "vintage": "new",
+            "n_installed_sensors": 2,
+            "message": "asset Pump-1 is a PUMP (new vintage) at PUMP-HOUSE with 2 installed sensors.",
+        }
+
+    @pytest.mark.anyio
+    async def test_reads_asset_registry_not_iot_db(self, mock_asset_db, mock_iot_db):
+        mock_asset_db.find.side_effect = [
+            {"docs": [{"siteid": "MAIN"}]},
+            {
+                "docs": [
+                    {
+                        "assetnum": "Pump-1",
+                        "description": "Registry pump",
+                        "assettype": "PUMP",
+                        "status": "OPERATING",
+                        "location": None,
+                        "installdate": None,
+                        "vintage": None,
+                        "sensors": [],
+                    }
+                ]
+            },
+        ]
+        mock_iot_db.find.return_value = {
+            "docs": [
+                {
+                    "asset_id": "Pump-1",
+                    "timestamp": "2024-01-01T00:00:00",
+                    "Telemetry Sensor": 42,
+                }
+            ]
+        }
+
+        data = await call_tool(
+            mcp, "get_asset_detail", {"site_name": "MAIN", "asset_id": "Pump-1"}
+        )
+
+        assert data["description"] == "Registry pump"
+        assert data["n_installed_sensors"] == 0
+        mock_iot_db.find.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_db_disconnected(self, no_asset_db):
+        data = await call_tool(
+            mcp, "get_asset_detail", {"site_name": "MAIN", "asset_id": "Pump-1"}
+        )
+        assert "error" in data
+        assert "not connected" in data["error"].lower()
+
+    @requires_couchdb
+    @pytest.mark.anyio
+    async def test_discovery_integration(self):
+        data = await call_tool(
+            mcp, "get_asset_detail", {"site_name": "MAIN", "asset_id": "Chiller 6"}
+        )
+        assert data["asset_id"] == "Chiller 6"
+        assert data["assettype"] == "CHILLER"
+        assert data["status"] == "OPERATING"
+        assert data["n_installed_sensors"] > 0
 
 
 class TestMeasuredSensors:

--- a/src/servers/iot/tests/test_tools.py
+++ b/src/servers/iot/tests/test_tools.py
@@ -91,11 +91,13 @@ class TestMeasuredSensors:
                     "_rev": "1-abc",
                     "asset_id": "Pump-1",
                     "timestamp": "2024-01-01T00:00:00",
+                    "dataset": "iot",
                     "Pressure": 10,
                 },
                 {
                     "asset_id": "Pump-1",
                     "timestamp": "2024-01-01T00:01:00",
+                    "dataset": "iot",
                     "Temperature": 30,
                     "Pressure": 11,
                 },


### PR DESCRIPTION
## Summary
- rename the IoT asset registry detail tool from `get_asset_detail(site_name, asset_id)` to `asset_detail(site_name, asset_id)`
- add `find_assets_by_sensors(site_name, sensors, match="all", substring=false, source="measured")` to find site-registered assets by installed registry sensors or measured telemetry fields
- add structured `FindAssetsResult` / `AssetSensorMatch` responses with the deduplicated query sensors and concrete matched sensor names per asset
- preserve existing registry/telemetry separation: `asset_detail`, `assets`, and `installed_sensors` read from `asset_db`; `measured_sensors` and `find_assets_by_sensors(source="measured")` read telemetry fields from `iot_db`
- deduplicate repeated sensor query terms before `match="all"` evaluation while preserving first occurrence order
- update README, MCP server docs, and tool docstrings to describe the current IoT tool surface and `find_assets_by_sensors` behavior
- add unit coverage for tool registration, renamed `asset_detail`, installed/measured sensor source behavior, substring matching, and duplicate query sensor handling

## Tool Surface
- `sites()` -> `{"sites": [...]}`
- `asset_ids(site_name)` -> bare asset id list for the site
- `asset_detail(site_name, asset_id)` -> asset registry details: `site_name`, `asset_id`, `description`, `assettype`, `status`, `location`, `installdate`, `vintage`, `n_installed_sensors`, `message`
- `assets(site_name, assettype?)` -> asset metadata rows: `asset_id`, `description`, `assettype`, `vintage`, `n_sensors`
- `installed_sensors(site_name, asset_id)` -> registry sensor inventory for an asset from `asset_db`
- `measured_sensors(site_name, asset_id)` -> observed telemetry field names for an asset from `iot_db`
- `find_assets_by_sensors(site_name, sensors, match?, substring?, source?)` -> assets whose installed or measured sensors match the query

## `find_assets_by_sensors` Behavior
- `source="installed"` searches each asset record's registry `sensors` inventory
- `source="measured"` searches telemetry field names discovered from IoT records
- `match="all"` requires every deduplicated query sensor to match
- `match="any"` requires at least one deduplicated query sensor to match
- `substring=true` performs case-insensitive substring matching
- duplicate query sensors are collapsed in `query_sensors` and do not cause false negatives for `match="all"`

## Tests
- `uv run --frozen pytest src/servers/iot/tests/test_tools.py` (31 passed)
- `/tmp/aob_find_assets_by_sensors_smoke.py` real-db smoke via `PYTHONPATH=src uv run --frozen python /tmp/aob_find_assets_by_sensors_smoke.py`
  - installed exact and substring searches returned expected assets
  - duplicate query search returned deduped `query_sensors`
  - measured exact and substring searches returned expected assets
  - invalid `match`, invalid `source`, empty sensors, and no-match cases returned expected responses
