### PR TITLE
feat(wo): read FCC failure codes from CouchDB

### DIFF
--- a/.env.public
+++ b/.env.public
@@ -4,6 +4,7 @@ COUCHDB_USERNAME=admin
 COUCHDB_PASSWORD=password
 IOT_DBNAME=iot
 WO_DBNAME=workorder
+FAILURE_CODE_DBNAME=failure_code
 
 # ── IBM WatsonX (plan-execute runner) ────────────────────────────────────────
 WATSONX_APIKEY=

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -94,6 +94,7 @@ See [MCP Servers](#mcp-servers) for available tools and [docs/mcp-servers.md](do
 | `COUCHDB_PASSWORD` | `password`              | CouchDB admin password   |
 | `IOT_DBNAME`         | `iot`                   | IoT sensor database name      |
 | `WO_DBNAME`          | `workorder`             | Work order database name      |
+| `FAILURE_CODE_DBNAME` | `failure_code`          | FCC failure-code database name |
 | `VIBRATION_DBNAME`   | `vibration`             | Vibration sensor database name |
 
 **WatsonX** — plan-execute runner and WatsonX-backed agent routes
@@ -143,7 +144,7 @@ Six FastMCP servers cover IoT data, time-series ML, work orders, vibration diagn
 | `iot`       | 7     | read                     | CouchDB  (telemetry + asset registry)  |
 | `utilities` | 3     | read                     | none                                   |
 | `fmsr`      | 2     | read, LLM-use            | LiteLLM + `failure_modes.yaml`         |
-| `wo`        | 14    | read, write              | CouchDB                                |
+| `wo`        | 15    | read, write              | CouchDB                                |
 | `tsfm`      | 6     | read, write, cpu-centric | IBM Granite TinyTimeMixer (torch)      |
 | `vibration` | 8     | read, cpu-centric        | CouchDB + numpy/scipy DSP              |
 

--- a/docs/data.md
+++ b/docs/data.md
@@ -269,7 +269,7 @@ folder's parent); data unique to a private scenario goes in that scenario's fold
 ## Gotchas
 
 - **Database name = manifest key.** Consumers must match: the WO MCP server reads
-  `WO_DBNAME=workorder`.
+  `WO_DBNAME=workorder` and `FAILURE_CODE_DBNAME=failure_code`.
 - **Shared paths resolve via the scenario folder's parent.** `shared/...` works because
   `shared/` sits beside the scenario folders under `scenarios_data/`. If you relocate the
   corpus, update the manifests (or use an explicit relative path).

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -71,10 +71,10 @@ Telemetry windows are half-open ISO 8601 ranges. `history` supports cursor-based
 ## wo — Work Order
 
 **Path:** `src/servers/wo/main.py`
-**Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `WO_DBNAME`)
+**Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `WO_DBNAME`, `FAILURE_CODE_DBNAME`)
 **Data init:** Handled automatically by `docker compose -f src/couchdb/docker-compose.yaml up` (runs `src/couchdb/init_wo.py` inside the CouchDB container on every start — database is dropped and reloaded each time)
 
-Tools fall into several categories: **read**, **write**, **LLM-use**, and **CPU-centric**. Tools are registered centrally in `main.py`; set `AOB_READONLY=1` to expose only the read tools (8). The default exposes all 14 (8 read + 6 write).
+Tools fall into several categories: **read**, **write**, **LLM-use**, and **CPU-centric**. Tools are registered centrally in `main.py`; set `AOB_READONLY=1` to expose only the read tools (9). The default exposes all 15 (9 read + 6 write).
 
 ### Read tools
 
@@ -88,6 +88,7 @@ Tools fall into several categories: **read**, **write**, **LLM-use**, and **CPU-
 | `get_workorder_kpis`                | read     | `site_id`, `period_months?`                                                          | Site KPIs: totals, backlog, overdue, avg completion, priority/asset splits |
 | `get_schedule_calendar`             | read     | `site_id`, `date_from?`, `date_to?`, `group_by?`                                     | Scheduled (non-terminal) work orders in a date window, bucketed by day     |
 | `get_my_assigned_workorders`        | read     | `labor_code`, `site_id?`, `open_only?`                                               | Work orders assigned to a given technician (labor code)                    |
+| `get_failure_codes`                 | read     | `code?`                                                                               | List FCC failure-code references or fetch one exact code from CouchDB      |
 
 ### Write tools
 

--- a/docs/stirrup-agent.md
+++ b/docs/stirrup-agent.md
@@ -99,8 +99,8 @@ asyncio.run(main())
 PY
 ```
 
-Expected counts: `iot` 4, `utilities` 3, `fmsr` 2, `tsfm` 6, `wo` 14, `vibration` 8
-(37 MCP tools total; the agent additionally has Stirrup's own `finish` tool).
+Expected counts: `iot` 4, `utilities` 3, `fmsr` 2, `tsfm` 6, `wo` 15, `vibration` 8
+(38 MCP tools total; the agent additionally has Stirrup's own `finish` tool).
 
 ---
 

--- a/src/servers/wo/main.py
+++ b/src/servers/wo/main.py
@@ -8,15 +8,16 @@ from AssetOpsBench is the *MCP server definition* convention: a single
 ``wo-mcp-server`` entry point.
 
 Env (AssetOpsBench-compatible): COUCHDB_URL, COUCHDB_USERNAME, COUCHDB_PASSWORD,
-WO_DBNAME. Set AOB_READONLY=1 to expose only the read tools.
+WO_DBNAME, FAILURE_CODE_DBNAME. Set AOB_READONLY=1 to expose only the read tools.
 """
 
 import logging
 import os
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
 from dotenv import load_dotenv
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
 from . import workorders as wo
 from .couch import CouchClient
@@ -24,6 +25,8 @@ from .models import (
     ActualsVsPlannedResult,
     CostsResult,
     ErrorResult,
+    FailureCodeItem,
+    FailureCodesResult,
     KpiResult,
     ScheduleResult,
     TasksResult,
@@ -48,6 +51,7 @@ mcp = FastMCP(
 )
 
 _db: Optional[CouchClient] = None
+_fcc_db: Optional[CouchClient] = None
 
 
 def db() -> CouchClient:
@@ -60,6 +64,18 @@ def db() -> CouchClient:
             password=os.environ.get("COUCHDB_PASSWORD", "password"),
         )
     return _db
+
+
+def failure_code_db() -> CouchClient:
+    global _fcc_db
+    if _fcc_db is None:
+        _fcc_db = CouchClient(
+            base_url=os.environ.get("COUCHDB_URL", "http://localhost:5984"),
+            db=os.environ.get("FAILURE_CODE_DBNAME", "failure_code"),
+            username=os.environ.get("COUCHDB_USERNAME", "admin"),
+            password=os.environ.get("COUCHDB_PASSWORD", "password"),
+        )
+    return _fcc_db
 
 
 # --------------------------------------------------------------------------- #
@@ -235,6 +251,33 @@ async def get_my_assigned_workorders(
     )
 
 
+async def get_failure_codes(
+    code: Optional[str] = None,
+) -> Union[FailureCodesResult, ErrorResult]:
+    """Read the FCC failure-code reference catalog from CouchDB.
+
+    Omit ``code`` to list all available failure codes, or pass an exact code
+    such as ``FC001``. Matching is case-insensitive and CouchDB metadata is not
+    returned.
+    """
+    res = await wo.get_failure_codes(failure_code_db(), code)
+    err = _failed(res)
+    if err:
+        return err
+    data = res["data"]
+    items = [FailureCodeItem.model_validate(item) for item in data["failure_codes"]]
+    query = data["code"]
+    message = f"Found {len(items)} failure code(s)."
+    if query:
+        message = f"Found {len(items)} failure code(s) for {query}."
+    return FailureCodesResult(
+        code=query,
+        total=data["totalCount"],
+        failure_codes=items,
+        message=message,
+    )
+
+
 async def generate_work_order(
     description: str,
     asset_num: str,
@@ -348,6 +391,7 @@ _READ_TOOLS = [
     (get_workorder_kpis, "Get Work Order KPIs"),
     (get_schedule_calendar, "Get Schedule Calendar"),
     (get_my_assigned_workorders, "Get My Assigned Work Orders"),
+    (get_failure_codes, "Get Failure Codes"),
 ]
 _WRITE_TOOLS = [
     (generate_work_order, "Generate Work Order"),
@@ -361,8 +405,16 @@ _WRITE_TOOLS = [
 _TOOLS = (
     _READ_TOOLS if os.environ.get("AOB_READONLY") == "1" else _READ_TOOLS + _WRITE_TOOLS
 )
+_TOOL_ANNOTATIONS = {
+    get_failure_codes: ToolAnnotations(
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    )
+}
 for _fn, _title in _TOOLS:
-    mcp.tool(title=_title)(_fn)
+    mcp.tool(title=_title, annotations=_TOOL_ANNOTATIONS.get(_fn))(_fn)
 
 
 def main():

--- a/src/servers/wo/models.py
+++ b/src/servers/wo/models.py
@@ -99,6 +99,18 @@ class WorkOrderResult(BaseModel):
     message: str
 
 
+class FailureCodeItem(BaseModel):
+    code: str
+    description: Optional[str] = None
+
+
+class FailureCodesResult(BaseModel):
+    code: Optional[str] = None
+    total: int
+    failure_codes: List[FailureCodeItem]
+    message: str
+
+
 class WorkOrderMutationResult(BaseModel):
     wonum: Optional[str] = None
     siteid: Optional[str] = None

--- a/src/servers/wo/tests/test_workorders.py
+++ b/src/servers/wo/tests/test_workorders.py
@@ -6,10 +6,13 @@ Run:  python -m pytest tests/ -q     (or just `python tests/test_workorders.py`)
 from __future__ import annotations
 
 import asyncio
-import re
+import json
 from datetime import datetime, timezone
 
-from servers.wo import workorders as wo
+import pytest
+
+from servers.wo import main, workorders as wo
+from servers.wo.models import ErrorResult, FailureCodesResult
 
 
 class FakeCouch:
@@ -190,6 +193,124 @@ async def scenario():
 
 def test_lifecycle():
     asyncio.run(scenario())
+
+
+def _fcc_db() -> FakeCouch:
+    db = FakeCouch()
+    db.docs = {
+        "fc:FC002": {
+            "_id": "fc:FC002",
+            "_rev": "1-test",
+            "dataset": "failure_code",
+            "code": "FC002",
+            "description": "equipment stops unexpectedly during operation",
+        },
+        "fc:FC001": {
+            "_id": "fc:FC001",
+            "_rev": "1-test",
+            "dataset": "failure_code",
+            "code": "FC001",
+            "description": "equipment does not start",
+        },
+    }
+    return db
+
+
+@pytest.mark.anyio
+async def test_reads_and_sorts_failure_code_catalog() -> None:
+    result = await wo.get_failure_codes(_fcc_db())
+
+    assert result["success"] is True
+    assert result["data"]["totalCount"] == 2
+    assert result["data"]["failure_codes"] == [
+        {"code": "FC001", "description": "equipment does not start"},
+        {
+            "code": "FC002",
+            "description": "equipment stops unexpectedly during operation",
+        },
+    ]
+    assert "_id" not in result["data"]["failure_codes"][0]
+    assert "_rev" not in result["data"]["failure_codes"][0]
+
+
+@pytest.mark.anyio
+async def test_exact_code_lookup_is_case_insensitive() -> None:
+    result = await wo.get_failure_codes(_fcc_db(), " fc002 ")
+
+    assert result["success"] is True
+    assert result["data"]["code"] == "FC002"
+    assert result["data"]["failure_codes"] == [
+        {
+            "code": "FC002",
+            "description": "equipment stops unexpectedly during operation",
+        }
+    ]
+
+
+@pytest.mark.anyio
+async def test_missing_exact_code_returns_empty_result() -> None:
+    result = await wo.get_failure_codes(_fcc_db(), "FC999")
+
+    assert result["success"] is True
+    assert result["data"]["totalCount"] == 0
+    assert result["data"]["failure_codes"] == []
+
+
+@pytest.mark.anyio
+async def test_failure_code_database_error_is_actionable() -> None:
+    class BrokenCouch:
+        async def find(self, *args, **kwargs):
+            raise RuntimeError("connection refused")
+
+    result = await wo.get_failure_codes(BrokenCouch())
+
+    assert result["success"] is False
+    assert result["error_code"] == "DATABASE_ERROR"
+    assert "FAILURE_CODE_DBNAME" in result["error"]
+    assert "connection refused" not in result["error"]
+
+
+@pytest.mark.anyio
+async def test_failure_code_mcp_boundary_returns_typed_result(monkeypatch) -> None:
+    monkeypatch.setattr(main, "_fcc_db", _fcc_db())
+
+    result = await main.get_failure_codes("fc001")
+
+    assert isinstance(result, FailureCodesResult)
+    assert result.code == "FC001"
+    assert result.total == 1
+    assert result.failure_codes[0].description == "equipment does not start"
+
+
+@pytest.mark.anyio
+async def test_failure_code_mcp_tool_is_registered_read_only(monkeypatch) -> None:
+    monkeypatch.setattr(main, "_fcc_db", _fcc_db())
+    tools = {tool.name: tool for tool in await main.mcp.list_tools()}
+
+    assert "get_failure_codes" in tools
+    assert tools["get_failure_codes"].annotations.readOnlyHint is True
+    assert tools["get_failure_codes"].annotations.destructiveHint is False
+
+    contents, _ = await main.mcp.call_tool("get_failure_codes", {"code": "FC002"})
+    data = json.loads(contents[0].text)
+    assert data["total"] == 1
+    assert data["failure_codes"][0]["code"] == "FC002"
+
+
+@pytest.mark.anyio
+async def test_failure_code_mcp_boundary_returns_typed_database_error(
+    monkeypatch,
+) -> None:
+    class BrokenCouch:
+        async def find(self, *args, **kwargs):
+            raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(main, "_fcc_db", BrokenCouch())
+
+    result = await main.get_failure_codes()
+
+    assert isinstance(result, ErrorResult)
+    assert "FAILURE_CODE_DBNAME" in result.error
 
 
 if __name__ == "__main__":

--- a/src/servers/wo/workorders.py
+++ b/src/servers/wo/workorders.py
@@ -18,6 +18,7 @@ binds a real client; tests bind an in-memory fake. Each returns the same
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, List, Optional
 
@@ -28,6 +29,8 @@ APPROVED_PENDING = ("APPR", "WMATL", "WSCH", "INPRG", "WPCOND")
 TERMINAL = ("COMP", "CLOSE", "CAN")
 ALL_STATUSES = OPEN_STATUSES + ("COMP", "CLOSE", "CAN")
 WORKTYPES = ("CM", "PM", "EM", "PdM", "CAL", "INSP", "GEN")
+FCC_QUERY_LIMIT = 1000
+logger = logging.getLogger("wo-mcp-server")
 
 
 def _doc_id(site_id: str, wonum: str) -> str:
@@ -43,9 +46,53 @@ def _public(doc: Dict[str, Any]) -> Dict[str, Any]:
     return {k: v for k, v in doc.items() if k not in ("_rev",)}
 
 
+def _failure_code_public(doc: Dict[str, Any]) -> Dict[str, Any]:
+    """Return only the FCC fields agents need."""
+    return {
+        "code": doc.get("code"),
+        "description": doc.get("description"),
+    }
+
+
 # --------------------------------------------------------------------------- #
 # Read tools
 # --------------------------------------------------------------------------- #
+async def get_failure_codes(db, code: Optional[str] = None) -> Dict[str, Any]:
+    """Read all FCC reference rows, or one exact failure code, from CouchDB."""
+    with Timer() as t:
+        normalized = code.strip().upper() if code and code.strip() else None
+        try:
+            if normalized:
+                doc = await db.get(f"fc:{normalized}")
+                docs = [doc] if doc else []
+            else:
+                docs = await db.find(
+                    {"dataset": "failure_code"},
+                    fields=["code", "description"],
+                    limit=FCC_QUERY_LIMIT,
+                )
+        except Exception as exc:
+            logger.error("Failed to read the failure-code catalog: %s", exc)
+            return error(
+                "Unable to read the failure-code catalog from CouchDB. Verify "
+                "CouchDB is running and FAILURE_CODE_DBNAME points to a loaded "
+                "database.",
+                "DATABASE_ERROR",
+            )
+
+        items = [_failure_code_public(doc) for doc in docs if doc and doc.get("code")]
+        items.sort(key=lambda item: item["code"])
+        return envelope(
+            {
+                "code": normalized,
+                "failure_codes": items,
+                "totalCount": len(items),
+            },
+            duration_ms=t_ms(t),
+            record_count=len(items),
+        )
+
+
 async def list_workorders(
     db,
     site_id: Optional[str] = None,
@@ -144,7 +191,10 @@ async def get_workorder_costs(db, wonum: str, site_id: str) -> Dict[str, Any]:
             return error(
                 f"Work order '{wonum}' not found in site '{site_id}'.", "NOT_FOUND"
             )
-        f = lambda n: float(wo.get(n) or 0)
+
+        def f(name: str) -> float:
+            return float(wo.get(name) or 0)
+
         labor, material, service, tool = (
             f("actlabcost"),
             f("actmatcost"),
@@ -190,7 +240,9 @@ async def get_workorder_actuals_vs_planned(
             return error(
                 f"Work order '{wonum}' not found in site '{site_id}'.", "NOT_FOUND"
             )
-        f = lambda n: float(wo.get(n) or 0)
+
+        def f(name: str) -> float:
+            return float(wo.get(name) or 0)
 
         def var(est, act):
             return {


### PR DESCRIPTION
## Description

Adds a read-only `get_failure_codes` MCP tool to the WO server. The tool reads the FCC reference catalog from the `failure_code` CouchDB database, lists all codes or fetches one exact code, and returns typed structured output without CouchDB metadata.

The change also adds:
- lazy `FAILURE_CODE_DBNAME` configuration (default: `failure_code`)
- read-only/idempotent MCP annotations
- actionable database errors without leaking backend details
- unit and MCP-boundary coverage
- updated server and data documentation

## Type of Change

- [ ] New Benchmark Scenario (Industry/Asset type)
- [ ] Evaluation Metric / Scorer
- [ ] Agentic Orchestration Logic (ReAct, Plan-Execute, etc.)
- [x] Infrastructure / Tooling Improvement

## Industry Relevance

Failure Code Classification workflows need a canonical list of allowed failure-code labels before assigning or validating codes on work orders. This tool exposes that reference set directly from the benchmark's CouchDB data layer.

## Related Issues

- No linked issue.

## Testing & Validation

- [x] **WO unit tests**: `.venv/bin/pytest src/servers/wo/tests -q` — 9 passed.
- [x] **Formatting/lint**: `uvx ruff format --check ...` and `uvx ruff check ...` passed for all changed Python files.
- [x] **Live CouchDB validation**: listed all 22 FCC labels and verified exact lookup `FC005` → `Structural deficiency` through the MCP tool.
- [x] **Read-only mode**: verified `AOB_READONLY=1` exposes 9 WO read tools including `get_failure_codes`.
- [x] **Data integrity**: no dataset rows or sensitive industrial data were added.

Repository-wide non-integration tests reached 482 passed, 195 skipped, and 16 deselected; 7 unrelated existing failures remain in direct-LLM output spacing and benchmark CLI test fixtures.

## Checklist

- [x] My code follows the project's Ruff formatting and linting rules.
- [x] I have performed a self-review of my code.
- [x] I have updated the documentation (README or /docs) accordingly.
- [x] I have signed off my commits (DCO).
