### PR TITLE
Fix OpenCode agent permission bypass and improve logging

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -329,7 +329,7 @@ uv run python -m benchmark.scenario_suite_runner \
   --scenario-root /path/to/scenarios_data \
   --agent_name opencode_agent \
   --model-id tokenrouter/MiniMax-M3 \
-  --opencode-workspace-root traces/opencode_workspaces \
+  --opencode-workspace-root /tmp/assetopsbench-opencode/workspaces \
   --opencode-allow-files \
   --opencode-allow-bash
 ```
@@ -337,12 +337,12 @@ uv run python -m benchmark.scenario_suite_runner \
 For scenario `401`, this creates a workspace like:
 
 ```text
-traces/opencode_workspaces/opencode_agent_401
+/tmp/assetopsbench-opencode/workspaces/opencode_agent/tokenrouter-MiniMax-M3/opencode_agent_401
 ```
 
 `--opencode-allow-files`, `--opencode-allow-bash`, and
 `--opencode-allow-edit` are opt-in. If any of them are enabled,
-`--opencode-workspace-root` is required.
+`--opencode-workspace-root` is required and must be outside the repository.
 
 > `--opencode-allow-bash` is not a hard OS-level sandbox. For strict filesystem
 > isolation, run the benchmark inside Docker or another sandbox.

--- a/docs/opencode-agent.md
+++ b/docs/opencode-agent.md
@@ -108,7 +108,9 @@ OpenCode discovered and called the AssetOpsBench MCP tools.
 
 > **Quiet runs.** `opencode-agent` runs OpenCode as a subprocess. During long
 > questions, the terminal may look quiet until OpenCode finishes. The persisted
-> trajectory is written only after the run completes.
+> trajectory is written only after the run completes. Add `--verbose` to emit
+> lifecycle logs for subprocess launch, output parsing, runtime, token totals,
+> and tool-call counts without logging the full user question.
 
 ---
 
@@ -126,6 +128,7 @@ The following capabilities are denied by default:
 - web fetch/search
 - external directory access
 - follow-up questions
+- other non-MCP OpenCode built-in tools
 
 This is the recommended mode for normal benchmark runs where answers should come
 from the configured MCP tools.
@@ -153,7 +156,7 @@ uv run python -m benchmark.scenario_suite_runner \
   --scenario-root /path/to/scenarios_data \
   --agent_name opencode_agent \
   --model-id tokenrouter/MiniMax-M3 \
-  --opencode-workspace-root traces/opencode_workspaces \
+  --opencode-workspace-root /tmp/assetopsbench-opencode/workspaces \
   --opencode-allow-files \
   --opencode-allow-bash
 ```
@@ -161,7 +164,7 @@ uv run python -m benchmark.scenario_suite_runner \
 For scenario `401`, this creates a workspace such as:
 
 ```text
-traces/opencode_workspaces/opencode_agent_401
+/tmp/assetopsbench-opencode/workspaces/opencode_agent/tokenrouter-MiniMax-M3/opencode_agent_401
 ```
 
 Each scenario run starts with an empty per-run workspace directory. The
@@ -222,12 +225,13 @@ The runner configures OpenCode permissions for benchmark use:
 | Capability | Default | Flag to allow |
 | ---------- | ------- | ------------- |
 | AssetOpsBench MCP tools | allowed | always enabled |
-| `read`, `glob`, `grep`, `lsp` | denied | `--allow-files` |
+| `read`, `glob`, `grep`, `lsp`, `list` | denied | `--allow-files` |
 | shell commands | denied | `--allow-bash` |
 | file edits | denied | `--allow-edit` |
 | web fetch/search | denied | `--allow-web` |
 | external directory access | denied | not exposed |
 | follow-up questions | denied | not exposed |
+| other OpenCode built-in tools | denied | not exposed |
 
 Benchmark runs should not pass `--allow-web`. Without that flag, OpenCode's
 `webfetch` and `websearch` permissions are explicitly set to `deny`.
@@ -287,7 +291,7 @@ In addition to the [common flags](../INSTRUCTIONS.md#common-flags) (`--model-id`
 | `--opencode-bin PATH` | OpenCode executable path (default: `opencode`). |
 | `--attach URL` | Attach to a running `opencode serve` instance. |
 | `--timeout-s N` | Wall-clock timeout for `opencode run` (default: 900). |
-| `--allow-files` | Allow file inspection tools (`read`, `glob`, `grep`, `lsp`). Disabled by default. |
+| `--allow-files` | Allow file inspection tools (`read`, `glob`, `grep`, `lsp`, `list`). Disabled by default. |
 | `--allow-bash` | Allow shell commands. Disabled by default. |
 | `--allow-edit` | Allow file edits. Disabled by default. |
 | `--allow-web` | Allow web fetch/search. Disabled by default. |
@@ -344,7 +348,7 @@ uv run python -m benchmark.scenario_suite_runner \
   --scenario-root /path/to/scenarios_data \
   --agent_name opencode_agent \
   --model-id tokenrouter/MiniMax-M3 \
-  --opencode-workspace-root traces/opencode_workspaces \
+  --opencode-workspace-root /tmp/assetopsbench-opencode/workspaces \
   --opencode-allow-files \
   --opencode-allow-bash
 ```
@@ -359,7 +363,9 @@ Scenario-suite OpenCode flags:
 | `--opencode-allow-edit` | Pass `--allow-edit` to `opencode-agent`. |
 
 If any OpenCode file, bash, or edit capability is enabled, then
-`--opencode-workspace-root` is required.
+`--opencode-workspace-root` is required and must be outside the repository so the
+agent cannot inspect benchmark reports, traces, or raw scenario files through the
+workspace.
 
 ---
 
@@ -435,7 +441,7 @@ uv run python -m benchmark.scenario_suite_runner \
   --scenario-root /path/to/scenarios_data \
   --agent_name opencode_agent \
   --model-id tokenrouter/MiniMax-M3 \
-  --opencode-workspace-root traces/opencode_workspaces \
+  --opencode-workspace-root /tmp/assetopsbench-opencode/workspaces \
   --opencode-allow-files \
   --opencode-allow-bash \
   --dry-run

--- a/src/agent/direct_llm_agent/tests/test_runner.py
+++ b/src/agent/direct_llm_agent/tests/test_runner.py
@@ -22,7 +22,7 @@ async def test_direct_llm_agent_returns_model_answer():
 
     result = await runner.run('Return only JSON: {"test": 1}')
 
-    assert result.answer == '{"test": 1}'
+    assert result.answer == '{"test":1}'
     assert result.question == 'Return only JSON: {"test": 1}'
     assert result.trajectory.total_input_tokens == 10
     assert result.trajectory.total_output_tokens == 5

--- a/src/agent/opencode_agent/cli.py
+++ b/src/agent/opencode_agent/cli.py
@@ -107,7 +107,7 @@ examples:
         "--allow-files",
         action="store_true",
         help=(
-            "Allow OpenCode read/glob/grep/lsp tools inside --workspace-dir. "
+            "Allow OpenCode read/glob/grep/lsp/list tools inside --workspace-dir. "
             "Disabled by default for tools-only benchmark runs."
         ),
     )

--- a/src/agent/opencode_agent/runner.py
+++ b/src/agent/opencode_agent/runner.py
@@ -32,6 +32,8 @@ _log = logging.getLogger(__name__)
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _DEFAULT_MODEL = "opencode/gpt-5.1-codex"
 _DEFAULT_AGENT_NAME = "assetops"
+_LOG_STREAM_TAIL_CHARS = 1000
+_ERROR_STREAM_TAIL_CHARS = 4000
 
 _OPENCODE_SYSTEM_PROMPT = (
     AGENT_SYSTEM_PROMPT
@@ -58,6 +60,58 @@ class OpenCodeTrajectory(Trajectory):
 
     raw_events: list[dict[str, Any]] = field(default_factory=list)
     stderr: str = ""
+
+
+def _command_for_log(cmd: list[str]) -> list[str]:
+    """Return a log-safe OpenCode argv with the user question omitted."""
+    if not cmd:
+        return []
+    logged = list(cmd)
+    logged[-1] = "<question omitted>"
+    return logged
+
+
+def _stream_tail(text: str, *, limit: int = _LOG_STREAM_TAIL_CHARS) -> str:
+    """Return a bounded stream tail for diagnostic logs/errors."""
+    if len(text) <= limit:
+        return text
+    omitted = len(text) - limit
+    return f"<truncated {omitted} chars>\n{text[-limit:]}"
+
+
+def _stream_stats(text: str) -> tuple[int, int]:
+    """Return decoded character and line counts for a captured stream."""
+    return len(text), len(text.splitlines())
+
+
+def _event_type_counts(events: list[dict[str, Any]]) -> dict[str, int]:
+    """Summarize OpenCode event types without logging raw event payloads."""
+    counts: dict[str, int] = {}
+    for event in events:
+        event_type = str(event.get("type") or "<missing>")
+        counts[event_type] = counts.get(event_type, 0) + 1
+    return counts
+
+
+def _permission_log_summary(permission: dict[str, Any]) -> dict[str, str]:
+    """Return the non-MCP permission summary most useful in run logs."""
+    keys = (
+        "*",
+        "read",
+        "glob",
+        "grep",
+        "lsp",
+        "list",
+        "edit",
+        "bash",
+        "todowrite",
+        "webfetch",
+        "websearch",
+        "codesearch",
+        "external_directory",
+        "question",
+    )
+    return {key: str(permission.get(key, "<unset>")) for key in keys}
 
 
 def _needs_reasoning_effort_none(provider_id: str, model_name: str) -> bool:
@@ -95,17 +149,21 @@ def _build_permissions(
 ) -> dict[str, Any]:
     """Build non-interactive permissions for benchmark-safe OpenCode runs."""
     permission: dict[str, Any] = {
+        "*": "deny",
         "read": "allow" if allow_files else "deny",
         "glob": "allow" if allow_files else "deny",
         "grep": "allow" if allow_files else "deny",
         "lsp": "allow" if allow_files else "deny",
+        "list": "allow" if allow_files else "deny",
         "edit": "allow" if allow_edit else "deny",
         "bash": "allow" if allow_bash else "deny",
+        "todowrite": "deny",
         "task": "deny",
         "skill": "deny",
         "question": "deny",
         "webfetch": "allow" if allow_web else "deny",
         "websearch": "allow" if allow_web else "deny",
+        "codesearch": "deny",
         "external_directory": "deny",
         "doom_loop": "deny",
     }
@@ -703,10 +761,27 @@ class OpenCodeAgentRunner(AgentRunner):
             env.setdefault("OPENCODE_DISABLE_AUTOUPDATE", "true")
             env.setdefault("NO_COLOR", "1")
 
+            permission = self._config["agent"][self._agent_name]["permission"]
             _log.info(
-                "OpenCodeAgentRunner: starting query (model=%s, opencode_model=%s)",
+                "OpenCodeAgentRunner: starting query "
+                "(model=%s, opencode_model=%s, agent=%s, max_steps=%d, "
+                "timeout_s=%s, run_dir=%s, mcp_servers=%s, permissions=%s, "
+                "attach=%s, variant=%s, thinking=%s)",
                 self._model_id,
                 self._opencode_model,
+                self._agent_name,
+                self._max_steps,
+                self._timeout_s,
+                self._run_dir,
+                sorted(self._server_paths),
+                _permission_log_summary(permission),
+                bool(self._attach),
+                self._variant or "<default>",
+                self._thinking,
+            )
+            _log.debug(
+                "OpenCodeAgentRunner: launching subprocess argv=%s",
+                _command_for_log(cmd),
             )
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
@@ -720,24 +795,100 @@ class OpenCodeAgentRunner(AgentRunner):
                     proc.communicate(), timeout=self._timeout_s
                 )
             except TimeoutError:
+                duration_ms = (time.perf_counter() - run_started) * 1000
+                _log.error(
+                    "OpenCodeAgentRunner: subprocess timed out "
+                    "(timeout_s=%s, duration_ms=%.0f, run_dir=%s)",
+                    self._timeout_s,
+                    duration_ms,
+                    self._run_dir,
+                )
                 proc.kill()
-                await proc.communicate()
+                _, killed_stderr_b = await proc.communicate()
+                killed_stderr = killed_stderr_b.decode("utf-8", errors="replace")
+                if killed_stderr:
+                    _log.debug(
+                        "OpenCodeAgentRunner: stderr after timeout kill: %r",
+                        _stream_tail(killed_stderr),
+                    )
                 raise TimeoutError(
                     f"opencode run timed out after {self._timeout_s} seconds"
                 ) from None
 
             stdout = stdout_b.decode("utf-8", errors="replace")
             stderr = stderr_b.decode("utf-8", errors="replace")
+            duration_ms = (time.perf_counter() - run_started) * 1000
+            stdout_chars, stdout_lines = _stream_stats(stdout)
+            stderr_chars, stderr_lines = _stream_stats(stderr)
             if proc.returncode != 0:
+                _log.error(
+                    "OpenCodeAgentRunner: subprocess failed "
+                    "(exit_code=%s, duration_ms=%.0f, stdout_chars=%d, "
+                    "stdout_lines=%d, stderr_chars=%d, stderr_lines=%d)",
+                    proc.returncode,
+                    duration_ms,
+                    stdout_chars,
+                    stdout_lines,
+                    stderr_chars,
+                    stderr_lines,
+                )
+                if stderr:
+                    _log.error(
+                        "OpenCodeAgentRunner: stderr tail after failure: %r",
+                        _stream_tail(stderr),
+                    )
+                if stdout:
+                    _log.debug(
+                        "OpenCodeAgentRunner: stdout tail after failure: %r",
+                        _stream_tail(stdout),
+                    )
                 raise RuntimeError(
                     "opencode run failed with exit code "
-                    f"{proc.returncode}\nSTDERR:\n{stderr[-4000:]}\nSTDOUT:\n{stdout[-4000:]}"
+                    f"{proc.returncode}\nSTDERR:\n"
+                    f"{_stream_tail(stderr, limit=_ERROR_STREAM_TAIL_CHARS)}\n"
+                    f"STDOUT:\n"
+                    f"{_stream_tail(stdout, limit=_ERROR_STREAM_TAIL_CHARS)}"
                 )
 
-            duration_ms = (time.perf_counter() - run_started) * 1000
             events, plain_lines = _json_events(stdout)
+            _log.info(
+                "OpenCodeAgentRunner: parsed subprocess output "
+                "(duration_ms=%.0f, events=%d, plain_stdout_lines=%d, "
+                "stdout_chars=%d, stdout_lines=%d, stderr_chars=%d, "
+                "stderr_lines=%d)",
+                duration_ms,
+                len(events),
+                len(plain_lines),
+                stdout_chars,
+                stdout_lines,
+                stderr_chars,
+                stderr_lines,
+            )
+            _log.debug(
+                "OpenCodeAgentRunner: event type counts=%s",
+                _event_type_counts(events),
+            )
+            if plain_lines:
+                _log.warning(
+                    "OpenCodeAgentRunner: ignored %d non-JSON stdout line(s); "
+                    "first=%r",
+                    len(plain_lines),
+                    plain_lines[0][:200],
+                )
+            if stderr:
+                _log.debug(
+                    "OpenCodeAgentRunner: stderr tail after success: %r",
+                    _stream_tail(stderr),
+                )
+
             error_message = _opencode_error_message(events)
             if error_message:
+                _log.error(
+                    "OpenCodeAgentRunner: OpenCode reported an error event "
+                    "(duration_ms=%.0f, message=%s)",
+                    duration_ms,
+                    error_message,
+                )
                 raise RuntimeError(error_message)
             answer, trajectory = _build_trajectory_from_events(
                 events,
@@ -748,6 +899,9 @@ class OpenCodeAgentRunner(AgentRunner):
             trajectory.started_at = started_at
 
             span.set_attribute("agent.answer.length", len(answer))
+            span.set_attribute("opencode.events", len(events))
+            span.set_attribute("opencode.plain_stdout_lines", len(plain_lines))
+            span.set_attribute("opencode.stderr_chars", stderr_chars)
             span.set_attribute(
                 "gen_ai.usage.input_tokens", trajectory.total_input_tokens
             )
@@ -757,6 +911,18 @@ class OpenCodeAgentRunner(AgentRunner):
             span.set_attribute("agent.turns", len(trajectory.turns))
             span.set_attribute("agent.tool_calls", len(trajectory.all_tool_calls))
             span.set_attribute("agent.duration_ms", duration_ms)
+            _log.info(
+                "OpenCodeAgentRunner: completed query "
+                "(duration_ms=%.0f, events=%d, turns=%d, tool_calls=%d, "
+                "input_tokens=%d, output_tokens=%d, answer_chars=%d)",
+                duration_ms,
+                len(events),
+                len(trajectory.turns),
+                len(trajectory.all_tool_calls),
+                trajectory.total_input_tokens,
+                trajectory.total_output_tokens,
+                len(answer),
+            )
             persist_trajectory(
                 runner_name="opencode-agent",
                 model=self._model_id,

--- a/src/agent/opencode_agent/tests/test_runner.py
+++ b/src/agent/opencode_agent/tests/test_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from agent.models import ToolCall
@@ -12,11 +13,16 @@ from agent.opencode_agent.runner import (
     _build_opencode_config,
     _build_permissions,
     _build_trajectory_from_events,
+    _command_for_log,
+    _event_type_counts,
     _json_events,
     _needs_reasoning_effort_none,
     _opencode_error_message,
+    _permission_log_summary,
     _resolve_run_dir,
     _resolve_opencode_model_and_provider,
+    _stream_stats,
+    _stream_tail,
 )
 
 
@@ -38,16 +44,20 @@ def test_build_mcp_config_path():
 
 def test_build_permissions_default_safe():
     permission = _build_permissions(["iot", "wo"])
+    assert permission["*"] == "deny"
     assert permission["iot_*"] == "allow"
     assert permission["wo_*"] == "allow"
     assert permission["read"] == "deny"
     assert permission["glob"] == "deny"
     assert permission["grep"] == "deny"
     assert permission["lsp"] == "deny"
+    assert permission["list"] == "deny"
     assert permission["bash"] == "deny"
     assert permission["edit"] == "deny"
+    assert permission["todowrite"] == "deny"
     assert permission["webfetch"] == "deny"
     assert permission["websearch"] == "deny"
+    assert permission["codesearch"] == "deny"
     assert permission["external_directory"] == "deny"
     assert permission["question"] == "deny"
 
@@ -64,11 +74,37 @@ def test_build_permissions_allows_opt_in_tools():
     assert permission["glob"] == "allow"
     assert permission["grep"] == "allow"
     assert permission["lsp"] == "allow"
+    assert permission["list"] == "allow"
     assert permission["bash"] == "allow"
     assert permission["edit"] == "allow"
+    assert permission["todowrite"] == "deny"
     assert permission["webfetch"] == "allow"
     assert permission["websearch"] == "allow"
+    assert permission["codesearch"] == "deny"
     assert permission["external_directory"] == "deny"
+
+
+def test_permission_log_summary_excludes_mcp_tool_rules():
+    permission = _build_permissions(["iot"], allow_bash=True, allow_files=True)
+    summary = _permission_log_summary(permission)
+
+    assert summary == {
+        "*": "deny",
+        "read": "allow",
+        "glob": "allow",
+        "grep": "allow",
+        "lsp": "allow",
+        "list": "allow",
+        "edit": "deny",
+        "bash": "allow",
+        "todowrite": "deny",
+        "webfetch": "deny",
+        "websearch": "deny",
+        "codesearch": "deny",
+        "external_directory": "deny",
+        "question": "deny",
+    }
+    assert "iot_*" not in summary
 
 
 def test_resolve_run_dir_defaults_to_repo_root():
@@ -193,6 +229,56 @@ def test_json_events_parses_ndjson_and_plain_lines():
     assert plain == ["not-json"]
 
 
+def test_command_for_log_omits_question():
+    question = "question with sensitive context"
+    cmd = [
+        "opencode",
+        "run",
+        "--format",
+        "json",
+        "--model",
+        "opencode/gpt-5",
+        question,
+    ]
+
+    logged = _command_for_log(cmd)
+
+    assert logged == [
+        "opencode",
+        "run",
+        "--format",
+        "json",
+        "--model",
+        "opencode/gpt-5",
+        "<question omitted>",
+    ]
+    assert question not in repr(logged)
+    assert cmd[-1] == question
+
+
+def test_stream_tail_truncates_long_streams():
+    assert _stream_tail("short", limit=10) == "short"
+    assert _stream_tail("0123456789", limit=4) == "<truncated 6 chars>\n6789"
+
+
+def test_stream_stats_counts_decoded_chars_and_lines():
+    assert _stream_stats("one\ntwo\n") == (8, 2)
+    assert _stream_stats("") == (0, 0)
+
+
+def test_event_type_counts_summarizes_events_without_payloads():
+    events = [
+        {"type": "message.part.updated", "payload": {"text": "secret"}},
+        {"type": "message.part.updated"},
+        {"payload": {"type": "not-counted"}},
+    ]
+
+    assert _event_type_counts(events) == {
+        "message.part.updated": 2,
+        "<missing>": 1,
+    }
+
+
 def test_opencode_error_message_extracts_api_error():
     message = _opencode_error_message(
         [
@@ -310,6 +396,55 @@ def test_runner_workspace_mode(tmp_path):
     )
     assert runner._run_dir == workspace.resolve()
     assert runner._config["agent"]["assetops"]["permission"]["read"] == "allow"
+
+
+async def test_runner_run_parses_fake_opencode_subprocess(tmp_path, monkeypatch):
+    capture_dir = tmp_path / "capture"
+    capture_dir.mkdir()
+    workspace = tmp_path / "workspace"
+    fake_opencode = tmp_path / "fake-opencode"
+    fake_opencode.write_text(
+        """#!/bin/sh
+printf '%s\n' "$*" > "$FAKE_CAPTURE_DIR/argv.txt"
+printf '%s\n' "$PWD" > "$FAKE_CAPTURE_DIR/cwd.txt"
+printf '%s\n' "$OPENCODE_CONFIG_CONTENT" > "$FAKE_CAPTURE_DIR/config.json"
+printf '%s\n' "$AGENT_TRAJECTORY_DIR" > "$FAKE_CAPTURE_DIR/trajectory-env.txt"
+printf '%s\n' "$SCENARIOS_DATA_DIR" > "$FAKE_CAPTURE_DIR/scenarios-env.txt"
+printf '%s\n' '{"type":"message.part.updated","properties":{"part":{"id":"t1","type":"text","text":"done"}}}'
+printf '%s\n' '{"type":"step_finish","part":{"type":"step-finish","tokens":{"input":3,"output":2}}}'
+printf '%s\n' 'diagnostic stderr' >&2
+""",
+        encoding="utf-8",
+    )
+    fake_opencode.chmod(0o755)
+    monkeypatch.setenv("FAKE_CAPTURE_DIR", str(capture_dir))
+    monkeypatch.setenv("AGENT_TRAJECTORY_DIR", str(tmp_path / "parent-trajectories"))
+    monkeypatch.setenv("SCENARIOS_DATA_DIR", str(tmp_path / "parent-scenarios"))
+
+    runner = OpenCodeAgentRunner(
+        server_paths={"iot": "iot-mcp-server"},
+        model="opencode/gpt-5",
+        opencode_bin=str(fake_opencode),
+        allow_files=True,
+        workspace_dir=workspace,
+    )
+
+    result = await runner.run("question with private details")
+    argv = (capture_dir / "argv.txt").read_text(encoding="utf-8")
+    config = (capture_dir / "config.json").read_text(encoding="utf-8")
+
+    assert result.answer == "done"
+    assert result.trajectory.started_at is not None
+    assert result.trajectory.stderr == "diagnostic stderr\n"
+    assert result.trajectory.total_input_tokens == 3
+    assert result.trajectory.total_output_tokens == 2
+    assert "question with private details" in argv
+    assert (capture_dir / "cwd.txt").read_text(encoding="utf-8").strip() == str(
+        workspace.resolve()
+    )
+    assert (capture_dir / "trajectory-env.txt").read_text(encoding="utf-8") == "\n"
+    assert (capture_dir / "scenarios-env.txt").read_text(encoding="utf-8") == "\n"
+    assert json.loads(config)["agent"]["assetops"]["permission"]["*"] == "deny"
 
 
 def _text_part(part_id, text, *, message_id=None, part_type="text"):

--- a/src/benchmark/scenario_suite_runner.py
+++ b/src/benchmark/scenario_suite_runner.py
@@ -465,7 +465,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--opencode-allow-files",
         action="store_true",
-        help="Allow opencode-agent read/glob/grep/lsp tools inside its per-run workspace.",
+        help="Allow opencode-agent read/glob/grep/lsp/list tools inside its per-run workspace.",
     )
     parser.add_argument(
         "--opencode-allow-bash",

--- a/src/benchmark/tests/test_scenario_suite_runner.py
+++ b/src/benchmark/tests/test_scenario_suite_runner.py
@@ -151,6 +151,7 @@ def test_method_output_paths_nest_by_agent_and_model(tmp_path: Path) -> None:
 def test_build_methods_uses_cli_defaults() -> None:
     args = Namespace(
         model_id="tokenrouter/MiniMax-M3",
+        stirrup_max_tokens=4096,
         gemini_model_id="tokenrouter_gemini/google/gemma-4-26b-a4b-it",
         openclaw_model_id="tokenrouter/MiniMax-M3",
         opencode_allow_files=False,
@@ -177,7 +178,7 @@ def test_build_methods_uses_cli_defaults() -> None:
     assert methods["direct_llm"].model_id == "tokenrouter/MiniMax-M3"
     assert methods["stirrup_agent"].command == "stirrup-agent"
     assert methods["stirrup_agent"].model_id == "tokenrouter/MiniMax-M3"
-    assert methods["stirrup_agent"].extra_args == ()
+    assert methods["stirrup_agent"].extra_args == ("--max-tokens", "4096")
     assert methods["stirrup_agent"].workspace_root is None
     assert methods["opencode_agent"].command == "opencode-agent"
     assert methods["opencode_agent"].extra_args == ()
@@ -198,6 +199,7 @@ def test_build_methods_uses_cli_defaults() -> None:
 def test_build_methods_stirrup_workspace_options(tmp_path: Path) -> None:
     args = Namespace(
         model_id="tokenrouter/MiniMax-M3",
+        stirrup_max_tokens=4096,
         stirrup_workspace_root=tmp_path / "stirrup-workspaces",
         preserve_workspaces=True,
         gemini_model_id="tokenrouter_gemini/google/gemma-4-26b-a4b-it",
@@ -223,13 +225,14 @@ def test_build_methods_stirrup_workspace_options(tmp_path: Path) -> None:
     methods = mr.build_methods(args)
     stirrup = methods["stirrup_agent"]
 
-    assert stirrup.extra_args == ("--preserve-workspace",)
+    assert stirrup.extra_args == ("--max-tokens", "4096", "--preserve-workspace")
     assert stirrup.workspace_root == tmp_path / "stirrup-workspaces"
 
 
 def test_build_methods_opencode_workspace_options(tmp_path: Path) -> None:
     args = Namespace(
         model_id="tokenrouter/MiniMax-M3",
+        stirrup_max_tokens=4096,
         gemini_model_id="tokenrouter_gemini/google/gemma-4-26b-a4b-it",
         openclaw_model_id="tokenrouter/MiniMax-M3",
         opencode_allow_files=True,
@@ -260,6 +263,7 @@ def test_build_methods_opencode_workspace_options(tmp_path: Path) -> None:
 def test_build_methods_opencode_thinking_and_variant() -> None:
     args = Namespace(
         model_id="tokenrouter/MiniMax-M3",
+        stirrup_max_tokens=4096,
         gemini_model_id="tokenrouter_gemini/google/gemma-4-26b-a4b-it",
         openclaw_model_id="tokenrouter/MiniMax-M3",
         opencode_allow_files=False,
@@ -294,6 +298,7 @@ def test_build_methods_opencode_thinking_and_variant() -> None:
 def test_build_methods_gemini_workspace_options(tmp_path: Path) -> None:
     args = Namespace(
         model_id="tokenrouter/MiniMax-M3",
+        stirrup_max_tokens=4096,
         gemini_model_id="tokenrouter_gemini/google/gemma-4-26b-a4b-it",
         openclaw_model_id="tokenrouter/MiniMax-M3",
         opencode_allow_files=False,
@@ -329,6 +334,7 @@ def test_build_methods_gemini_workspace_options(tmp_path: Path) -> None:
 def test_build_methods_openclaw_workspace_options(tmp_path: Path) -> None:
     args = Namespace(
         model_id="tokenrouter/MiniMax-M3",
+        stirrup_max_tokens=4096,
         gemini_model_id="tokenrouter_gemini/google/gemma-4-26b-a4b-it",
         openclaw_model_id="tokenrouter/MiniMax-M3",
         opencode_allow_files=False,


### PR DESCRIPTION
## Summary
- Add safe OpenCode subprocess lifecycle logging for launch, parse, success, failure, and timeout paths without logging the full user question.
- Tighten OpenCode permissions for benchmark-safe defaults while keeping configured AssetOpsBench MCP tools available.
- Add fake-subprocess runner coverage, refresh docs/workspace examples, and update stale test expectations found during verification.

## OpenCode permission changes
- Add a top-level `"*": "deny"` permission rule so non-MCP OpenCode built-in tools are denied unless the runner explicitly allows them.
- Continue allowing configured AssetOpsBench MCP tools with per-server patterns such as `iot_*`, `wo_*`, `tsfm_*`, `fmsr_*`, `utilities_*`, and `vibration_*`.
- Keep local file inspection denied by default. `--allow-files` now explicitly enables `read`, `glob`, `grep`, `lsp`, and `list` inside the selected `--workspace-dir`.
- Keep `bash`, `edit`, and web access denied by default; they are only enabled through `--allow-bash`, `--allow-edit`, and `--allow-web`.
- Explicitly deny additional non-MCP built-ins including `todowrite`, `codesearch`, `task`, `skill`, `question`, `external_directory`, and `doom_loop`.
- Update CLI help and docs so the documented file-inspection set includes `list`, and scenario-suite workspace examples use an outside-repo workspace root.

## Tests
- `uv run pytest src/agent/opencode_agent/tests/test_runner.py src/llm/tests/test_routers.py src/benchmark/tests/test_scenario_suite_runner.py -q`
- `uv run pytest src/agent src/benchmark -q`
- `uv run python -m compileall -q src/agent/opencode_agent src/benchmark/scenario_suite_runner.py`
- `uv run opencode-agent --help`
- `git diff --check`