### PR TITLE
docs: clarify TSFM anomaly run recipe path

### DIFF
--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -154,10 +154,6 @@ the full output. The server supplies evidence; the agent makes the decisions.
 | `resolve_model` | read | `model_id` | Preflight: confirm a card can be loaded and report where its weights come from. Does not download or fit. |
 | `hf_stats` | read | `model_id?`, `hf_repo?` | Read-only HuggingFace popularity lookup for a model card or repo. Returns downloads and likes; needs network to huggingface.co. |
 
-For anomaly detection, choose a detector here first: use
-`find_models(task_id="tsfm_anomaly_detection")` or `search_models`, then pass the selected
-`model_id` as the `run_recipe` estimator.
-
 ### Model catalog — authoring and lifecycle
 
 | Tool | Category | Arguments | Description |
@@ -198,11 +194,6 @@ The catalog describes models; these tools **run** them. A recipe names an estima
 from the catalog, or an inline `sktime_class` + `params`) plus optional blocks. `run_recipe`
 compiles it, backtests it, produces a forecast or anomaly output, and persists a run record.
 `recipe_template` returns the contract so an agent does not have to guess the shape.
-
-For anomaly detection: select a detector with `find_models(task_id="tsfm_anomaly_detection")` or
-`search_models`, then call `run_recipe` with task `tsfm_anomaly_detection` and estimator
-`{"model_id": "<model_id>"}`. Base final segment/JSON answers on the returned labels, indices, and
-`results_file`.
 
 | Tool | Category | Arguments | Description |
 | ---- | -------- | --------- | ----------- |

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -154,6 +154,11 @@ the full output. The server supplies evidence; the agent makes the decisions.
 | `resolve_model` | read | `model_id` | Preflight: confirm a card can be loaded and report where its weights come from. Does not download or fit. |
 | `hf_stats` | read | `model_id?`, `hf_repo?` | Read-only HuggingFace popularity lookup for a model card or repo. Returns downloads and likes; needs network to huggingface.co. |
 
+For anomaly-detection tasks, choose the estimator from this catalog before executing a run:
+`find_models(task_id="tsfm_anomaly_detection")` is the direct path, while `search_models` is useful
+when the request names a detector family or tag. The selected card must include
+`tsfm_anomaly_detection` in `task_ids`; pass its `model_id` to `run_recipe` in the recipe estimator.
+
 ### Model catalog — authoring and lifecycle
 
 | Tool | Category | Arguments | Description |
@@ -194,6 +199,12 @@ The catalog describes models; these tools **run** them. A recipe names an estima
 from the catalog, or an inline `sktime_class` + `params`) plus optional blocks. `run_recipe`
 compiles it, backtests it, produces a forecast or anomaly output, and persists a run record.
 `recipe_template` returns the contract so an agent does not have to guess the shape.
+
+For time-series anomaly detection, use the model-catalog tools first, then execute:
+`find_models(task_id="tsfm_anomaly_detection")` or `search_models` -> select a model card ->
+`run_recipe` with `recipe={"task": "tsfm_anomaly_detection", "estimator": {"model_id":
+"<selected_model_id>"}}`. Base the final anomaly segment/JSON answer on the returned anomaly count,
+indices, labels, and `results_file` payload.
 
 | Tool | Category | Arguments | Description |
 | ---- | -------- | --------- | ----------- |

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -154,10 +154,9 @@ the full output. The server supplies evidence; the agent makes the decisions.
 | `resolve_model` | read | `model_id` | Preflight: confirm a card can be loaded and report where its weights come from. Does not download or fit. |
 | `hf_stats` | read | `model_id?`, `hf_repo?` | Read-only HuggingFace popularity lookup for a model card or repo. Returns downloads and likes; needs network to huggingface.co. |
 
-For anomaly-detection tasks, choose the estimator from this catalog before executing a run:
-`find_models(task_id="tsfm_anomaly_detection")` is the direct path, while `search_models` is useful
-when the request names a detector family or tag. The selected card must include
-`tsfm_anomaly_detection` in `task_ids`; pass its `model_id` to `run_recipe` in the recipe estimator.
+For anomaly detection, choose a detector here first: use
+`find_models(task_id="tsfm_anomaly_detection")` or `search_models`, then pass the selected
+`model_id` as the `run_recipe` estimator.
 
 ### Model catalog — authoring and lifecycle
 
@@ -200,11 +199,10 @@ from the catalog, or an inline `sktime_class` + `params`) plus optional blocks. 
 compiles it, backtests it, produces a forecast or anomaly output, and persists a run record.
 `recipe_template` returns the contract so an agent does not have to guess the shape.
 
-For time-series anomaly detection, use the model-catalog tools first, then execute:
-`find_models(task_id="tsfm_anomaly_detection")` or `search_models` -> select a model card ->
-`run_recipe` with `recipe={"task": "tsfm_anomaly_detection", "estimator": {"model_id":
-"<selected_model_id>"}}`. Base the final anomaly segment/JSON answer on the returned anomaly count,
-indices, labels, and `results_file` payload.
+For anomaly detection: select a detector with `find_models(task_id="tsfm_anomaly_detection")` or
+`search_models`, then call `run_recipe` with task `tsfm_anomaly_detection` and estimator
+`{"model_id": "<model_id>"}`. Base final segment/JSON answers on the returned labels, indices, and
+`results_file`.
 
 | Tool | Category | Arguments | Description |
 | ---- | -------- | --------- | ----------- |

--- a/src/servers/tsfm/main.py
+++ b/src/servers/tsfm/main.py
@@ -80,17 +80,11 @@ mcp = FastMCP(
     instructions=(
         "The TSFM server provides task discovery, file-pointer evidence tools, recipe execution, "
         "and CouchDB-backed model and feature catalog tools for forecasting and anomaly detection. "
-        "Use `recipe_template` before `run_recipe`. For anomaly-detection questions, first use "
-        "`find_models(task_id=\"tsfm_anomaly_detection\")` or `search_models` to select a "
-        "catalog model whose `task_ids` include `tsfm_anomaly_detection`; then call "
-        "`run_recipe` with `recipe={\"task\": \"tsfm_anomaly_detection\", \"estimator\": "
-        "{\"model_id\": \"<selected_model_id>\"}}`. "
-        "Anomaly runs screen the target series and return dense anomaly labels, anomaly counts, "
-        "run records, and results-file pointers; base any final anomaly segment/JSON answer on "
-        "those flagged outputs, opening `results_file` if exact labels are needed. Use the model "
-        "tools to browse, resolve, register, fine-tune, version, or deprecate model cards; use the "
-        "feature tools to browse, register, version, or deprecate transform/extractor cards. "
-        "Catalog cards are data, not weights; `MODEL_CATALOG_DBNAME` and "
+        "Use `recipe_template` before `run_recipe`. For anomaly detection, select a detector with "
+        "`find_models(task_id=\"tsfm_anomaly_detection\")` or `search_models`; call "
+        "`run_recipe` with `recipe={\"task\": \"tsfm_anomaly_detection\", \"estimator\": {\"model_id\": "
+        "\"<model_id>\"}}`; ground final segment/JSON answers in returned labels, indices, or "
+        "`results_file`. Catalog cards are pointers, not weights; `MODEL_CATALOG_DBNAME` and "
         "`FEATURE_CATALOG_DBNAME` select the backing collections."
     ),
 )
@@ -370,10 +364,8 @@ def search_models(
 ) -> Union[ModelsResult, ErrorResult]:
     """Substring (case-insensitive) search over the model catalog.
 
-    This is a model-catalog discovery tool. For anomaly detection, use it to locate candidate
-    detector cards by text/tags, or call `find_models(task_id="tsfm_anomaly_detection")` when you
-    already know the task. Select a returned card whose `task_ids` include
-    `tsfm_anomaly_detection`, then pass its `model_id` to `run_recipe` as the recipe estimator.
+    Use this for text/tag discovery. For anomaly detection, select a card whose `task_ids`
+    include `tsfm_anomaly_detection`, then pass its `model_id` as the `run_recipe` estimator.
 
     Args:
         text: Required substring to match against id, description, family, or tags.
@@ -410,9 +402,8 @@ def find_models(
     card for a task (e.g. to build a leaderboard or map model ids to their params), use
     `list_models`, which applies no `top_k` limit.
 
-    For time-series anomaly detection, call `find_models(task_id="tsfm_anomaly_detection")` to
-    select a detector card before execution. Pass the selected `model_id` to `run_recipe` with
-    `recipe={"task": "tsfm_anomaly_detection", "estimator": {"model_id": "<selected>"}}`.
+    For anomaly detection, use `task_id="tsfm_anomaly_detection"` and pass the selected
+    `model_id` as the `run_recipe` estimator.
 
     Cards lacking filtered fields are excluded from the shortlist.
 
@@ -1574,14 +1565,11 @@ def run_recipe(
 ) -> Union[RecipeResult, ErrorResult]:
     """Run a forecasting or anomaly-detection recipe on a target series from a file pointer.
 
-    Use this as the execution tool for time-series anomaly detection after choosing a detector
-    with the model-catalog tools. Prefer `find_models(task_id="tsfm_anomaly_detection")` or
-    `search_models`, select a card whose `task_ids` include `tsfm_anomaly_detection`, then pass
-    `recipe={"task": "tsfm_anomaly_detection", "estimator": {"model_id": "<selected>"}}`.
-    The anomaly path fits or resolves the detector, screens the target series, and returns dense
-    anomaly labels, anomaly counts, indexed run/result records, and a `results_file` pointer.
-    Base any final anomaly segment/JSON answer on those flagged outputs. Recipes without that task
-    are forecasting
+    For anomaly detection, first select a detector with
+    `find_models(task_id="tsfm_anomaly_detection")` or `search_models`; call `run_recipe` with
+    `recipe={"task": "tsfm_anomaly_detection", "estimator": {"model_id": "<model_id>"}}`.
+    The anomaly path returns dense labels, counts, indexed records, and a `results_file` pointer;
+    ground final segment/JSON answers in those outputs. Recipes without that task are forecasting
     (transforms + single/ensemble + optional conformal intervals). Use `recipe_template()` for the
     recipe contract. The result is also findable later via `list_runs()` / `get_run()` and
     `list_results()` / `get_result()`.

--- a/src/servers/tsfm/main.py
+++ b/src/servers/tsfm/main.py
@@ -84,8 +84,7 @@ mcp = FastMCP(
         "`find_models(task_id=\"tsfm_anomaly_detection\")` or `search_models`; call "
         "`run_recipe` with `recipe={\"task\": \"tsfm_anomaly_detection\", \"estimator\": {\"model_id\": "
         "\"<model_id>\"}}`; ground final segment/JSON answers in returned labels, indices, or "
-        "`results_file`. Catalog cards are pointers, not weights; `MODEL_CATALOG_DBNAME` and "
-        "`FEATURE_CATALOG_DBNAME` select the backing collections."
+        "`results_file`."
     ),
 )
 

--- a/src/servers/tsfm/main.py
+++ b/src/servers/tsfm/main.py
@@ -80,13 +80,18 @@ mcp = FastMCP(
     instructions=(
         "The TSFM server provides task discovery, file-pointer evidence tools, recipe execution, "
         "and CouchDB-backed model and feature catalog tools for forecasting and anomaly detection. "
-        "Use `recipe_template` before `run_recipe`; call `run_recipe` for anomaly detection by "
-        "setting recipe['task'] to `tsfm_anomaly_detection` and providing a detector estimator. "
+        "Use `recipe_template` before `run_recipe`. For anomaly-detection questions, first use "
+        "`find_models(task_id=\"tsfm_anomaly_detection\")` or `search_models` to select a "
+        "catalog model whose `task_ids` include `tsfm_anomaly_detection`; then call "
+        "`run_recipe` with `recipe={\"task\": \"tsfm_anomaly_detection\", \"estimator\": "
+        "{\"model_id\": \"<selected_model_id>\"}}`. "
         "Anomaly runs screen the target series and return dense anomaly labels, anomaly counts, "
-        "run records, and results-file pointers. Use the model tools to browse, resolve, register, "
-        "fine-tune, version, or deprecate model cards; use the feature tools to browse, register, "
-        "version, or deprecate transform/extractor cards. Catalog cards are data, not weights; "
-        "`MODEL_CATALOG_DBNAME` and `FEATURE_CATALOG_DBNAME` select the backing collections."
+        "run records, and results-file pointers; base any final anomaly segment/JSON answer on "
+        "those flagged outputs, opening `results_file` if exact labels are needed. Use the model "
+        "tools to browse, resolve, register, fine-tune, version, or deprecate model cards; use the "
+        "feature tools to browse, register, version, or deprecate transform/extractor cards. "
+        "Catalog cards are data, not weights; `MODEL_CATALOG_DBNAME` and "
+        "`FEATURE_CATALOG_DBNAME` select the backing collections."
     ),
 )
 
@@ -365,6 +370,11 @@ def search_models(
 ) -> Union[ModelsResult, ErrorResult]:
     """Substring (case-insensitive) search over the model catalog.
 
+    This is a model-catalog discovery tool. For anomaly detection, use it to locate candidate
+    detector cards by text/tags, or call `find_models(task_id="tsfm_anomaly_detection")` when you
+    already know the task. Select a returned card whose `task_ids` include
+    `tsfm_anomaly_detection`, then pass its `model_id` to `run_recipe` as the recipe estimator.
+
     Args:
         text: Required substring to match against id, description, family, or tags.
         tags: Optional required tag set.
@@ -399,6 +409,10 @@ def find_models(
     Returns at most `top_k` cards (default 5) - this is a SHORTLIST tool. To enumerate every
     card for a task (e.g. to build a leaderboard or map model ids to their params), use
     `list_models`, which applies no `top_k` limit.
+
+    For time-series anomaly detection, call `find_models(task_id="tsfm_anomaly_detection")` to
+    select a detector card before execution. Pass the selected `model_id` to `run_recipe` with
+    `recipe={"task": "tsfm_anomaly_detection", "estimator": {"model_id": "<selected>"}}`.
 
     Cards lacking filtered fields are excluded from the shortlist.
 
@@ -1560,11 +1574,14 @@ def run_recipe(
 ) -> Union[RecipeResult, ErrorResult]:
     """Run a forecasting or anomaly-detection recipe on a target series from a file pointer.
 
-    Use this as the execution tool for time-series anomaly detection: set `recipe["task"]` to
-    `tsfm_anomaly_detection` and provide a detector `estimator` (`model_id` or inline
-    `sktime_class` + `params`). The anomaly path fits or resolves the detector, screens the target
-    series, and returns dense anomaly labels, anomaly counts, indexed run/result records, and a
-    `results_file` pointer. Recipes without that task are forecasting
+    Use this as the execution tool for time-series anomaly detection after choosing a detector
+    with the model-catalog tools. Prefer `find_models(task_id="tsfm_anomaly_detection")` or
+    `search_models`, select a card whose `task_ids` include `tsfm_anomaly_detection`, then pass
+    `recipe={"task": "tsfm_anomaly_detection", "estimator": {"model_id": "<selected>"}}`.
+    The anomaly path fits or resolves the detector, screens the target series, and returns dense
+    anomaly labels, anomaly counts, indexed run/result records, and a `results_file` pointer.
+    Base any final anomaly segment/JSON answer on those flagged outputs. Recipes without that task
+    are forecasting
     (transforms + single/ensemble + optional conformal intervals). Use `recipe_template()` for the
     recipe contract. The result is also findable later via `list_runs()` / `get_run()` and
     `list_results()` / `get_result()`.

--- a/src/servers/tsfm/main.py
+++ b/src/servers/tsfm/main.py
@@ -80,11 +80,11 @@ mcp = FastMCP(
     instructions=(
         "The TSFM server provides task discovery, file-pointer evidence tools, recipe execution, "
         "and CouchDB-backed model and feature catalog tools for forecasting and anomaly detection. "
-        "Use `recipe_template` before `run_recipe`. For anomaly detection, select a detector with "
-        "`find_models(task_id=\"tsfm_anomaly_detection\")` or `search_models`; call "
-        "`run_recipe` with `recipe={\"task\": \"tsfm_anomaly_detection\", \"estimator\": {\"model_id\": "
-        "\"<model_id>\"}}`; ground final segment/JSON answers in returned labels, indices, or "
-        "`results_file`."
+        "For anomaly detection, follow this workflow: 1) call `recipe_template` to confirm the "
+        "recipe shape; 2) choose a detector with `find_models(task_id=\"tsfm_anomaly_detection\")` "
+        "or `search_models`; 3) call `run_recipe` with `recipe={\"task\": "
+        "\"tsfm_anomaly_detection\", \"estimator\": {\"model_id\": \"<model_id>\"}}`; "
+        "4) report the anomalous segment from returned labels, indices, or `results_file`."
     ),
 )
 

--- a/src/servers/tsfm/main.py
+++ b/src/servers/tsfm/main.py
@@ -1,4 +1,9 @@
-"""TSFM MCP server for task evidence, model cards, and feature cards.
+"""TSFM MCP server for time-series evidence, catalogs, and recipe execution.
+
+The MCP-facing tools help agents profile asset time series, choose catalog cards, and run
+forecasting or anomaly-detection recipes. In particular, `run_recipe` dispatches
+`recipe["task"] == "tsfm_anomaly_detection"` to the detector path and returns anomaly labels,
+counts, run records, and results-file pointers.
 
 Catalogs are CouchDB data loaded by src/couchdb/init_data.py; `MODEL_CATALOG_DBNAME` and
 `FEATURE_CATALOG_DBNAME` select the collections. Model cards are pointers to loadable models,
@@ -73,8 +78,12 @@ logger = logging.getLogger("tsfm-mcp-server")
 mcp = FastMCP(
     "tsfm",
     instructions=(
-        "The TSFM server provides task discovery, file-pointer evidence tools, and CouchDB-backed "
-        "model and feature catalog tools. Use the model tools to browse, resolve, register, "
+        "The TSFM server provides task discovery, file-pointer evidence tools, recipe execution, "
+        "and CouchDB-backed model and feature catalog tools for forecasting and anomaly detection. "
+        "Use `recipe_template` before `run_recipe`; call `run_recipe` for anomaly detection by "
+        "setting recipe['task'] to `tsfm_anomaly_detection` and providing a detector estimator. "
+        "Anomaly runs screen the target series and return dense anomaly labels, anomaly counts, "
+        "run records, and results-file pointers. Use the model tools to browse, resolve, register, "
         "fine-tune, version, or deprecate model cards; use the feature tools to browse, register, "
         "version, or deprecate transform/extractor cards. Catalog cards are data, not weights; "
         "`MODEL_CATALOG_DBNAME` and `FEATURE_CATALOG_DBNAME` select the backing collections."
@@ -1438,7 +1447,9 @@ def recipe_template() -> RecipeTemplateResult:
     Read this before run_recipe. A recipe is the agent's decision surface: it names the model and
     every choice around it, and the server executes exactly what it says. Static - it reads nothing
     from the catalog. Pair it with find_models / describe_candidates to choose a `model_id`, and
-    resolve_model to preflight that the card loads.
+    resolve_model to preflight that the card loads. For anomaly detection, set
+    `recipe["task"] == "tsfm_anomaly_detection"` and provide a detector estimator; `run_recipe`
+    will route that recipe to the anomaly detector path.
 
     Returns:
         RecipeTemplateResult: `task_choices` (what recipe["task"] dispatches on), `estimator_spec`
@@ -1547,22 +1558,26 @@ def run_recipe(
     asset_id: str = "asset",
     parent_run_id: Optional[str] = None,
 ) -> Union[RecipeResult, ErrorResult]:
-    """Run a forecasting or anomaly recipe on a series from a file pointer.
+    """Run a forecasting or anomaly-detection recipe on a target series from a file pointer.
 
-    Dispatches by `recipe['task']`: `tsfm_anomaly_detection` takes the detector path
-    (e.g. tspulse zero-shot, sublof) and produces dense anomaly labels; anything else is
-    forecasting (transforms + single/ensemble + optional conformal intervals). Use
-    `recipe_template()` for the recipe contract. The result is also findable later via
-    `list_runs()` / `get_run()` and `list_results()` / `get_result()`.
+    Use this as the execution tool for time-series anomaly detection: set `recipe["task"]` to
+    `tsfm_anomaly_detection` and provide a detector `estimator` (`model_id` or inline
+    `sktime_class` + `params`). The anomaly path fits or resolves the detector, screens the target
+    series, and returns dense anomaly labels, anomaly counts, indexed run/result records, and a
+    `results_file` pointer. Recipes without that task are forecasting
+    (transforms + single/ensemble + optional conformal intervals). Use `recipe_template()` for the
+    recipe contract. The result is also findable later via `list_runs()` / `get_run()` and
+    `list_results()` / `get_result()`.
 
     Args:
         dataset_path: File pointer to the input series (from the evidence tools or
             `materialize_iot`).
         timestamp_column: Name of the time column used to order the series.
-        target_columns: The column(s) to forecast or screen. Must not be empty.
+        target_columns: The column(s) to forecast or screen for anomalies. Must not be empty.
         recipe: The recipe dict: an `estimator` (a catalog `model_id`, or an inline
             `sktime_class` + `params`) or an `ensemble`, plus optional blocks (`fh`,
-            `transforms`, `conformal`, `finetune`, `save_to`, `eval`, ...). See
+            `transforms`, `conformal`, `finetune`, `save_to`, `eval`, ...). For anomaly detection,
+            include `task: "tsfm_anomaly_detection"` and a detector estimator. See
             `recipe_template()`.
         asset_id: Asset this run belongs to; used to group runs and results.
         parent_run_id: Optional id of a parent run, for chaining within a plan.

--- a/src/servers/tsfm/tests/test_run_tools.py
+++ b/src/servers/tsfm/tests/test_run_tools.py
@@ -48,6 +48,18 @@ def test_run_surface_present():
             "get_result", "list_results", "get_run", "list_runs"} <= names
 
 
+def test_mcp_guidance_advertises_anomaly_run_recipe_path():
+    instructions = mcp.instructions
+    assert "anomaly detection" in instructions
+    assert "run_recipe" in instructions
+    assert "tsfm_anomaly_detection" in instructions
+
+    descriptions = {t.name: (t.description or "") for t in asyncio.run(mcp.list_tools())}
+    run_recipe_doc = descriptions["run_recipe"]
+    assert "time-series anomaly detection" in run_recipe_doc
+    assert "tsfm_anomaly_detection" in run_recipe_doc
+
+
 # ---- run_recipe: a real fit + backtest ----
 def test_run_recipe_fits_and_backtests():
     r = call("run_recipe", {"dataset_path": _series(), "timestamp_column": "timestamp",

--- a/src/servers/tsfm/tests/test_run_tools.py
+++ b/src/servers/tsfm/tests/test_run_tools.py
@@ -51,12 +51,15 @@ def test_run_surface_present():
 def test_mcp_guidance_advertises_anomaly_run_recipe_path():
     instructions = mcp.instructions
     assert "anomaly detection" in instructions
+    assert "For anomaly detection, follow this workflow" in instructions
+    assert "recipe_template" in instructions
     assert "find_models(task_id=\"tsfm_anomaly_detection\")" in instructions
     assert "search_models" in instructions
     assert "run_recipe" in instructions
     assert "tsfm_anomaly_detection" in instructions
     assert "\"estimator\": {\"model_id\": \"<model_id>\"}" in instructions
     assert "returned labels, indices" in instructions
+    assert "report the anomalous segment" in instructions
 
     descriptions = {t.name: (t.description or "") for t in asyncio.run(mcp.list_tools())}
     search_models_doc = descriptions["search_models"]

--- a/src/servers/tsfm/tests/test_run_tools.py
+++ b/src/servers/tsfm/tests/test_run_tools.py
@@ -55,23 +55,22 @@ def test_mcp_guidance_advertises_anomaly_run_recipe_path():
     assert "search_models" in instructions
     assert "run_recipe" in instructions
     assert "tsfm_anomaly_detection" in instructions
-    assert "\"estimator\": {\"model_id\": \"<selected_model_id>\"}" in instructions
-    assert "flagged outputs" in instructions
+    assert "\"estimator\": {\"model_id\": \"<model_id>\"}" in instructions
+    assert "returned labels, indices" in instructions
 
     descriptions = {t.name: (t.description or "") for t in asyncio.run(mcp.list_tools())}
     search_models_doc = descriptions["search_models"]
-    assert "model-catalog discovery tool" in search_models_doc
+    assert "text/tag discovery" in search_models_doc
     assert "task_ids" in search_models_doc
 
     find_models_doc = descriptions["find_models"]
-    assert "find_models(task_id=\"tsfm_anomaly_detection\")" in find_models_doc
+    assert "task_id=\"tsfm_anomaly_detection\"" in find_models_doc
 
     run_recipe_doc = descriptions["run_recipe"]
-    assert "time-series anomaly detection" in run_recipe_doc
-    assert "model-catalog tools" in run_recipe_doc
+    assert "For anomaly detection" in run_recipe_doc
     assert "tsfm_anomaly_detection" in run_recipe_doc
-    assert "\"estimator\": {\"model_id\": \"<selected>\"}" in run_recipe_doc
-    assert "final anomaly segment/JSON answer" in run_recipe_doc
+    assert "\"estimator\": {\"model_id\": \"<model_id>\"}" in run_recipe_doc
+    assert "ground final segment/JSON answers" in run_recipe_doc
 
 
 # ---- run_recipe: a real fit + backtest ----

--- a/src/servers/tsfm/tests/test_run_tools.py
+++ b/src/servers/tsfm/tests/test_run_tools.py
@@ -51,13 +51,27 @@ def test_run_surface_present():
 def test_mcp_guidance_advertises_anomaly_run_recipe_path():
     instructions = mcp.instructions
     assert "anomaly detection" in instructions
+    assert "find_models(task_id=\"tsfm_anomaly_detection\")" in instructions
+    assert "search_models" in instructions
     assert "run_recipe" in instructions
     assert "tsfm_anomaly_detection" in instructions
+    assert "\"estimator\": {\"model_id\": \"<selected_model_id>\"}" in instructions
+    assert "flagged outputs" in instructions
 
     descriptions = {t.name: (t.description or "") for t in asyncio.run(mcp.list_tools())}
+    search_models_doc = descriptions["search_models"]
+    assert "model-catalog discovery tool" in search_models_doc
+    assert "task_ids" in search_models_doc
+
+    find_models_doc = descriptions["find_models"]
+    assert "find_models(task_id=\"tsfm_anomaly_detection\")" in find_models_doc
+
     run_recipe_doc = descriptions["run_recipe"]
     assert "time-series anomaly detection" in run_recipe_doc
+    assert "model-catalog tools" in run_recipe_doc
     assert "tsfm_anomaly_detection" in run_recipe_doc
+    assert "\"estimator\": {\"model_id\": \"<selected>\"}" in run_recipe_doc
+    assert "final anomaly segment/JSON answer" in run_recipe_doc
 
 
 # ---- run_recipe: a real fit + backtest ----


### PR DESCRIPTION
## Summary
- clarify TSFM MCP guidance for anomaly-detection recipes in server instructions and docstrings
- add coverage that the MCP guidance advertises the anomaly run_recipe path

## Tests
- pytest src/servers/tsfm/tests/test_run_tools.py -q