### PR TITLE
Enable OpenCode workspace writes with bash

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -275,7 +275,7 @@ uv run direct-llm-agent "$query"
 | `--max-steps N`                | opencode-agent | Max OpenCode agentic iterations (default: 30)                      |
 | `--attach URL`                 | opencode-agent | Attach to a running `opencode serve` instance                      |
 | `--allow-files` / `--workspace-dir PATH` | opencode-agent | Enable local file inspection in a dedicated workspace              |
-| `--allow-bash` / `--allow-edit` / `--allow-web` | opencode-agent | Opt into shell, file edits, or web access; all denied by default |
+| `--allow-bash` / `--allow-edit` / `--allow-web` | opencode-agent | Opt into shell plus workspace writes, workspace writes without shell, or web access; all denied by default |
 
 ### Examples
 
@@ -304,7 +304,7 @@ STIRRUP_CODE_IMAGE=assetops-code \
 # OpenCode MCP-only CLI-backed agent, using TokenRouter
 uv run opencode-agent --model-id tokenrouter/MiniMax-M3 --show-trajectory "$query"
 
-# OpenCode CLI workspace mode, allowing file inspection and bash in a run workspace
+# OpenCode CLI workspace mode, allowing file inspection, workspace writes, and bash
 uv run opencode-agent \
   --model-id tokenrouter/MiniMax-M3 \
   --workspace-dir /tmp/assetopsbench-opencode/smoke \
@@ -341,7 +341,8 @@ For scenario `401`, this creates a workspace like:
 ```
 
 `--opencode-allow-files`, `--opencode-allow-bash`, and
-`--opencode-allow-edit` are opt-in. If any of them are enabled,
+`--opencode-allow-edit` are opt-in. `--opencode-allow-bash` also permits
+workspace file writes so agents can save output artifacts. If any of them are enabled,
 `--opencode-workspace-root` is required and must be outside the repository.
 
 > `--opencode-allow-bash` is not a hard OS-level sandbox. For strict filesystem

--- a/docs/opencode-agent.md
+++ b/docs/opencode-agent.md
@@ -13,7 +13,8 @@ explicitly enabled.
 
 The runner also supports an optional **CLI workspace mode**. In that mode, each
 benchmark run gets a dedicated workspace directory and OpenCode can be allowed
-to inspect files and/or run shell commands inside that run workspace.
+to inspect files, create output files, and/or run shell commands inside that run
+workspace.
 
 ## Contents
 
@@ -144,7 +145,7 @@ uv run python -m benchmark.scenario_suite_runner \
 ### CLI workspace mode
 
 CLI workspace mode is opt-in. It gives each OpenCode run a dedicated workspace
-directory and can allow file inspection and/or shell execution.
+directory and can allow file inspection, file writes, and/or shell execution.
 
 This mode is useful when evaluating CLI-style agents that can write small Python
 scripts, run local analysis, and use intermediate artifacts while still using
@@ -227,7 +228,7 @@ The runner configures OpenCode permissions for benchmark use:
 | AssetOpsBench MCP tools | allowed | always enabled |
 | `read`, `glob`, `grep`, `lsp`, `list` | denied | `--allow-files` |
 | shell commands | denied | `--allow-bash` |
-| file edits | denied | `--allow-edit` |
+| workspace file writes | denied | `--allow-edit` or `--allow-bash` |
 | web fetch/search | denied | `--allow-web` |
 | external directory access | denied | not exposed |
 | follow-up questions | denied | not exposed |
@@ -292,8 +293,8 @@ In addition to the [common flags](../INSTRUCTIONS.md#common-flags) (`--model-id`
 | `--attach URL` | Attach to a running `opencode serve` instance. |
 | `--timeout-s N` | Wall-clock timeout for `opencode run` (default: 900). |
 | `--allow-files` | Allow file inspection tools (`read`, `glob`, `grep`, `lsp`, `list`). Disabled by default. |
-| `--allow-bash` | Allow shell commands. Disabled by default. |
-| `--allow-edit` | Allow file edits. Disabled by default. |
+| `--allow-bash` | Allow shell commands and workspace file writes. Disabled by default. |
+| `--allow-edit` | Allow workspace file writes without shell commands. Disabled by default. |
 | `--allow-web` | Allow web fetch/search. Disabled by default. |
 | `--workspace-dir PATH` | Workspace directory required when files, bash, or edits are enabled. |
 | `--ask-permissions` | Do not auto-approve allowed permissions. Not suitable for batch runs. |

--- a/src/agent/opencode_agent/cli.py
+++ b/src/agent/opencode_agent/cli.py
@@ -91,7 +91,10 @@ examples:
     parser.add_argument(
         "--allow-bash",
         action="store_true",
-        help="Allow OpenCode's bash tool. Disabled by default for benchmark runs.",
+        help=(
+            "Allow OpenCode's bash tool and workspace file writes. "
+            "Disabled by default for benchmark runs."
+        ),
     )
     parser.add_argument(
         "--allow-edit",

--- a/src/agent/opencode_agent/runner.py
+++ b/src/agent/opencode_agent/runner.py
@@ -148,6 +148,7 @@ def _build_permissions(
     allow_files: bool = False,
 ) -> dict[str, Any]:
     """Build non-interactive permissions for benchmark-safe OpenCode runs."""
+    allow_workspace_writes = allow_edit or allow_bash
     permission: dict[str, Any] = {
         "*": "deny",
         "read": "allow" if allow_files else "deny",
@@ -155,7 +156,7 @@ def _build_permissions(
         "grep": "allow" if allow_files else "deny",
         "lsp": "allow" if allow_files else "deny",
         "list": "allow" if allow_files else "deny",
-        "edit": "allow" if allow_edit else "deny",
+        "edit": "allow" if allow_workspace_writes else "deny",
         "bash": "allow" if allow_bash else "deny",
         "todowrite": "deny",
         "task": "deny",

--- a/src/agent/opencode_agent/tests/test_runner.py
+++ b/src/agent/opencode_agent/tests/test_runner.py
@@ -84,6 +84,20 @@ def test_build_permissions_allows_opt_in_tools():
     assert permission["external_directory"] == "deny"
 
 
+def test_build_permissions_allows_writes_with_bash_workspace_mode():
+    permission = _build_permissions(["iot"], allow_bash=True)
+
+    assert permission["bash"] == "allow"
+    assert permission["edit"] == "allow"
+
+
+def test_build_permissions_allows_edits_without_bash():
+    permission = _build_permissions(["iot"], allow_edit=True)
+
+    assert permission["edit"] == "allow"
+    assert permission["bash"] == "deny"
+
+
 def test_permission_log_summary_excludes_mcp_tool_rules():
     permission = _build_permissions(["iot"], allow_bash=True, allow_files=True)
     summary = _permission_log_summary(permission)
@@ -95,7 +109,7 @@ def test_permission_log_summary_excludes_mcp_tool_rules():
         "grep": "allow",
         "lsp": "allow",
         "list": "allow",
-        "edit": "deny",
+        "edit": "allow",
         "bash": "allow",
         "todowrite": "deny",
         "webfetch": "deny",

--- a/src/benchmark/scenario_suite_runner.py
+++ b/src/benchmark/scenario_suite_runner.py
@@ -458,8 +458,9 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help=(
             "Root directory for per-run OpenCode workspaces. Required when "
-            "using --opencode-allow-files, --opencode-allow-bash, or "
-            "--opencode-allow-edit. Workspaces are nested by agent/model/run_id."
+            "using --opencode-allow-files, --opencode-allow-bash "
+            "(bash plus workspace writes), or --opencode-allow-edit. "
+            "Workspaces are nested by agent/model/run_id."
         ),
     )
     parser.add_argument(
@@ -470,7 +471,10 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--opencode-allow-bash",
         action="store_true",
-        help="Allow opencode-agent bash in its per-run workspace.",
+        help=(
+            "Allow opencode-agent bash and workspace file writes in its "
+            "per-run workspace."
+        ),
     )
     parser.add_argument(
         "--opencode-allow-edit",
@@ -604,7 +608,7 @@ def main() -> None:
     if opencode_workspace_required and args.opencode_workspace_root is None:
         parser.error(
             "--opencode-workspace-root is required when enabling OpenCode "
-            "files, bash, or edits"
+            "files, bash/workspace writes, or edits"
         )
     if opencode_workspace_required:
         try:


### PR DESCRIPTION
## Summary
- allow OpenCode workspace file writes when --allow-bash is enabled
- update CLI help and docs to describe bash workspace write behavior
- add permission tests for bash-enabled writes and edit-only writes

## Validation
- uv run pytest src/agent/opencode_agent/tests/ -q
- live smoke verified BAT-02 CSV creation with --allow-files --allow-bash