### PR TITLE
Correctly score noisy multiple-choice answers in static_json evaluator

### DIFF
--- a/src/evaluation/scorers/static_json.py
+++ b/src/evaluation/scorers/static_json.py
@@ -539,6 +539,98 @@ def _evaluate_mode_json(gold_answer: Any, model_answer: Any) -> StaticJsonScore:
     )
 
 
+_MCQ_CHOICE_RE = re.compile(r"^[A-Za-z]$")
+
+_MCQ_ANSWER_PHRASE_RE = re.compile(
+    r"(?:final\s+answer|correct\s+answer|answer|choice|option)"
+    r"\s*(?:is|:|=)?\s*\(?\b([A-Za-z])\b\)?",
+    re.IGNORECASE,
+)
+_MCQ_STANDALONE_RE = re.compile(
+    r"(?<![A-Za-z0-9])([A-Za-z])(?:[.)\]]|\s*$)", re.MULTILINE
+)
+
+
+def _is_mcq_gold_answer(value: Any) -> bool:
+    """True when the gold answer is a bare single-letter MCQ choice, e.g. 'C'."""
+    parsed = parse_structured_answer(value)
+    return isinstance(parsed, str) and bool(_MCQ_CHOICE_RE.fullmatch(parsed.strip()))
+
+
+def extract_mcq_choice(text: Any) -> str | None:
+    """Extract the final single-letter MCQ choice from noisy model output.
+
+    Handles both explicit phrasing ("the answer is C") and reasoning that
+    simply trails off into a standalone letter on its own line.
+    """
+    if not isinstance(text, str):
+        return None
+
+    content = _strip_markdown_fence(extract_answer_text(text))
+
+    phrase_matches = list(_MCQ_ANSWER_PHRASE_RE.finditer(content))
+    if phrase_matches:
+        return phrase_matches[-1].group(1).upper()
+
+    standalone_matches = list(_MCQ_STANDALONE_RE.finditer(content.strip()))
+    if standalone_matches:
+        return standalone_matches[-1].group(1).upper()
+
+    return None
+
+
+def _evaluate_mcq_choice(gold_answer: Any, model_answer: Any) -> StaticJsonScore:
+    gold_letter = str(parse_structured_answer(gold_answer)).strip().upper()
+    model_letter = extract_mcq_choice(model_answer)
+    match = model_letter == gold_letter
+    score_val = 1.0 if match else 0.0
+
+    details = [
+        KeyComparison(
+            key="answer.mcq_choice",
+            gold_value=gold_letter,
+            model_value=model_letter or "MISSING",
+            exact=match,
+            match_type=(
+                "exact"
+                if match
+                else "no_choice_found"
+                if not model_letter
+                else "mismatch"
+            ),
+            similarity=score_val,
+            accepted=match,
+        )
+    ]
+
+    return StaticJsonScore(
+        partial_match_accuracy=score_val,
+        partial_exact_match_accuracy=score_val,
+        strict_exact_match_accuracy=score_val,
+        partial_similarity_score=score_val,
+        partial_numeric_match_accuracy=0.0,
+        range_match_accuracy=0.0,
+        delta_1_match_accuracy=0.0,
+        precision=score_val,
+        recall=score_val,
+        f1=score_val,
+        total_gold_keys=1,
+        total_model_keys=1 if model_letter else 0,
+        matched_keys=1 if match else 0,
+        accepted_value_matches=1 if match else 0,
+        exact_value_matches=1 if match else 0,
+        numeric_gold_keys=0,
+        numeric_value_matches=0,
+        range_eligible_keys=0,
+        range_value_matches=0,
+        delta_1_eligible_keys=0,
+        delta_1_value_matches=0,
+        missing_keys=[] if match else ["answer"],
+        extra_keys=[],
+        details=details,
+    )
+
+
 _NUMBER_RE = r"[+-]?\d+(?:\.\d+)?"
 _RANGE_FIELD_PAIRS = (
     ("start_point", "end_point"),
@@ -726,6 +818,9 @@ def evaluate_static_json(
     """Evaluate one structured gold answer against one model answer."""
     if _is_mode_gold_answer(gold_answer):
         return _evaluate_mode_json(gold_answer, model_answer)
+
+    if _is_mcq_gold_answer(gold_answer):
+        return _evaluate_mcq_choice(gold_answer, model_answer)
 
     gold_flat = flatten_answer(gold_answer)
     model_flat = flatten_answer(model_answer)

--- a/src/evaluation/tests/test_static_json_scorer.py
+++ b/src/evaluation/tests/test_static_json_scorer.py
@@ -339,3 +339,44 @@ def test_static_json_scorer_wrapper_exact_match():
     assert result.passed is True
     assert result.score == 1.0
     assert result.details["strict_exact_match_accuracy"] == 1.0
+
+
+def test_mcq_exact_letter_match():
+    score = evaluate_static_json("C", "C")
+
+    assert score.strict_exact_match_accuracy == 1.0
+    assert score.details[0].match_type == "exact"
+
+
+def test_mcq_matches_answer_is_phrasing_with_trailing_explanation():
+    score = evaluate_static_json(
+        "C", "After comparing the options, the answer is C."
+    )
+
+    assert score.strict_exact_match_accuracy == 1.0
+    assert score.details[0].model_value == "C"
+
+
+def test_mcq_matches_standalone_trailing_letter_without_answer_keyword():
+    score = evaluate_static_json(
+        "C",
+        "The vibration signature and temperature trend both point toward "
+        "bearing wear rather than lubrication loss.\n\nC",
+    )
+
+    assert score.strict_exact_match_accuracy == 1.0
+    assert score.details[0].model_value == "C"
+
+
+def test_mcq_wrong_letter_fails():
+    score = evaluate_static_json("C", "The answer is B.")
+
+    assert score.strict_exact_match_accuracy == 0.0
+    assert score.details[0].model_value == "B"
+
+
+def test_mcq_no_choice_found_fails_without_crashing():
+    score = evaluate_static_json("C", "I am unable to determine an answer.")
+
+    assert score.strict_exact_match_accuracy == 0.0
+    assert score.details[0].match_type == "no_choice_found"


### PR DESCRIPTION
## What's going wrong

For multiple-choice questions, the correct answer is stored as a single letter, like `"C"`. When an AI agent is graded, its answer gets compared against that letter.

In practice, agents don't just reply with a bare letter — they explain themselves first:

> "After comparing the options, the answer is C."

or they reason through the problem and land on the letter at the very end:

> "...the temperature and vibration data both point to bearing wear...
>
> C"

Both of these picked the right answer. But the grading code was comparing the agent's *entire paragraph* against the single letter `"C"` as if they were meant to be identical. A paragraph never equals one letter, so these correct answers were being marked as **incorrect**, dragging down the reported accuracy for no real reason.

## Why it happened

The grading code had a way to pull a "final answer" out of messy text, but it only recognized a label like `"Answer:"` sitting at the very start of a line. It didn't account for:
1. The letter being mentioned *in the middle of a sentence* ("the answer is C"), or
2. The letter appearing by itself at the *end* of the response with no label at all.

Since neither situation was recognized, the code fell back to treating the whole response as the answer — which could never match a single letter.

## The solution

Added a step that runs specifically for single-letter, multiple-choice questions:

1. **Recognize** when the correct answer is just one letter (an MCQ-style question).
2. **Pull out** the agent's actual chosen letter from its response, using two checks, in order:
   - First, look anywhere in the text for phrasing such as "answer is C," "final answer: C," or "choice: C."
   - If that doesn't turn up anything, fall back to the last letter that stands on its own in the response (e.g., sitting alone on the final line, or followed by a period).
3. **Compare** just that one extracted letter against the correct letter — the surrounding explanation is no longer part of the comparison.

Every other type of question (JSON objects, numbers, yes/no-style "mode" answers) is graded exactly as before — this change only kicks in for single-letter MCQ questions.

## How I confirmed it works

- Added 5 new tests in `test_static_json_scorer.py`: a plain exact match, the "answer is X" phrasing case, the standalone-trailing-letter case, a wrong-letter case (confirms bad answers still correctly score as wrong), and a case with no identifiable letter at all (confirms it fails gracefully instead of crashing).
- Ran the complete existing test suite for this module — **78 out of 78 passed**, so no other scoring paths were disturbed.

## Test plan

- [x] `uv run pytest src/evaluation/tests/test_static_json_scorer.py -v` — 30/30 passed
- [x] `uv run pytest src/evaluation/tests/` — 78/78 passed

Closes #475
