### PR TITLE
Disable tool streaming for TokenRouter Claude

### DIFF
--- a/src/agent/opencode_agent/cli.py
+++ b/src/agent/opencode_agent/cli.py
@@ -35,7 +35,7 @@ environment variables:
   LITELLM_API_KEY         LiteLLM router key for litellm_proxy/* models
   LITELLM_BASE_URL        LiteLLM OpenAI-compatible base URL
   TOKENROUTER_API_KEY     TokenRouter key for tokenrouter/* models
-  TOKENROUTER_BASE_URL    TokenRouter OpenAI-compatible base URL
+  TOKENROUTER_BASE_URL    TokenRouter base URL; Claude models use Anthropic protocol
 
 examples:
   opencode-agent "What assets are at site MAIN?"

--- a/src/agent/opencode_agent/cli.py
+++ b/src/agent/opencode_agent/cli.py
@@ -35,7 +35,7 @@ environment variables:
   LITELLM_API_KEY         LiteLLM router key for litellm_proxy/* models
   LITELLM_BASE_URL        LiteLLM OpenAI-compatible base URL
   TOKENROUTER_API_KEY     TokenRouter key for tokenrouter/* models
-  TOKENROUTER_BASE_URL    TokenRouter base URL; Claude models use Anthropic protocol
+  TOKENROUTER_BASE_URL    TokenRouter OpenAI-compatible base URL
 
 examples:
   opencode-agent "What assets are at site MAIN?"

--- a/src/agent/opencode_agent/runner.py
+++ b/src/agent/opencode_agent/runner.py
@@ -179,9 +179,8 @@ def _resolve_opencode_model_and_provider(
     """Translate AssetOpsBench router model IDs into OpenCode config.
 
     OpenCode wants ``provider/model``.  For AssetOpsBench router prefixes such
-    as ``litellm_proxy/`` and ``tokenrouter/``, declare a custom provider and
-    register the requested model explicitly. TokenRouter Claude models need the
-    Anthropic protocol so OpenCode preserves native Anthropic message handling.
+    as ``litellm_proxy/`` and ``tokenrouter/``, declare a custom
+    OpenAI-compatible provider and register the requested model explicitly.
     """
     creds = resolve_router_creds(model_id, strict=True)
     if creds is None:
@@ -191,11 +190,7 @@ def _resolve_opencode_model_and_provider(
     provider_name = "TokenRouter" if provider_id == "tokenrouter" else "LiteLLM Proxy"
     model_name = resolve_model(model_id)
     opencode_model = f"{provider_id}/{model_name}"
-    provider_npm = (
-        "@ai-sdk/anthropic"
-        if provider_id == "tokenrouter" and model_name.startswith("anthropic/")
-        else "@ai-sdk/openai-compatible"
-    )
+    provider_npm = "@ai-sdk/openai-compatible"
     model_config: dict[str, Any] = {"name": model_name}
     if _needs_reasoning_effort_none(provider_id, model_name):
         # TokenRouter rejects function tools for OpenAI GPT-5 models on

--- a/src/agent/opencode_agent/runner.py
+++ b/src/agent/opencode_agent/runner.py
@@ -179,8 +179,9 @@ def _resolve_opencode_model_and_provider(
     """Translate AssetOpsBench router model IDs into OpenCode config.
 
     OpenCode wants ``provider/model``.  For AssetOpsBench router prefixes such
-    as ``litellm_proxy/`` and ``tokenrouter/``, declare a custom
-    OpenAI-compatible provider and register the requested model explicitly.
+    as ``litellm_proxy/`` and ``tokenrouter/``, declare a custom provider and
+    register the requested model explicitly. TokenRouter Claude models need the
+    Anthropic protocol so OpenCode preserves native Anthropic message handling.
     """
     creds = resolve_router_creds(model_id, strict=True)
     if creds is None:
@@ -190,12 +191,23 @@ def _resolve_opencode_model_and_provider(
     provider_name = "TokenRouter" if provider_id == "tokenrouter" else "LiteLLM Proxy"
     model_name = resolve_model(model_id)
     opencode_model = f"{provider_id}/{model_name}"
-    provider_npm = "@ai-sdk/openai-compatible"
+    is_tokenrouter_anthropic = (
+        provider_id == "tokenrouter" and model_name.startswith("anthropic/")
+    )
+    provider_npm = (
+        "@ai-sdk/anthropic"
+        if is_tokenrouter_anthropic
+        else "@ai-sdk/openai-compatible"
+    )
     model_config: dict[str, Any] = {"name": model_name}
     if _needs_reasoning_effort_none(provider_id, model_name):
         # TokenRouter rejects function tools for OpenAI GPT-5 models on
         # chat/completions unless reasoning_effort is explicitly disabled.
         model_config["options"] = {"reasoningEffort": "none"}
+    if is_tokenrouter_anthropic:
+        # Custom Anthropic gateways can reject replayed streamed tool-use input
+        # when OpenCode records malformed partial args as a string.
+        model_config["options"] = {"toolStreaming": False}
     provider = {
         provider_id: {
             "npm": provider_npm,

--- a/src/agent/opencode_agent/tests/test_runner.py
+++ b/src/agent/opencode_agent/tests/test_runner.py
@@ -190,7 +190,7 @@ def test_resolve_tokenrouter_anthropic_model(monkeypatch):
         "tokenrouter/anthropic/claude-opus-4.8"
     )
     assert model == "tokenrouter/anthropic/claude-opus-4.8"
-    assert provider["tokenrouter"]["npm"] == "@ai-sdk/anthropic"
+    assert provider["tokenrouter"]["npm"] == "@ai-sdk/openai-compatible"
     assert provider["tokenrouter"]["options"]["baseURL"] == "https://router.example/v1"
     assert (
         provider["tokenrouter"]["models"]["anthropic/claude-opus-4.8"]["name"]

--- a/src/agent/opencode_agent/tests/test_runner.py
+++ b/src/agent/opencode_agent/tests/test_runner.py
@@ -190,11 +190,14 @@ def test_resolve_tokenrouter_anthropic_model(monkeypatch):
         "tokenrouter/anthropic/claude-opus-4.8"
     )
     assert model == "tokenrouter/anthropic/claude-opus-4.8"
-    assert provider["tokenrouter"]["npm"] == "@ai-sdk/openai-compatible"
+    assert provider["tokenrouter"]["npm"] == "@ai-sdk/anthropic"
     assert provider["tokenrouter"]["options"]["baseURL"] == "https://router.example/v1"
     assert (
-        provider["tokenrouter"]["models"]["anthropic/claude-opus-4.8"]["name"]
-        == "anthropic/claude-opus-4.8"
+        provider["tokenrouter"]["models"]["anthropic/claude-opus-4.8"]
+        == {
+            "name": "anthropic/claude-opus-4.8",
+            "options": {"toolStreaming": False},
+        }
     )
     assert (
         env["ASSETOPSBENCH_OPENCODE_API_KEY"] == "tr-test"


### PR DESCRIPTION
## Summary
- Keep `tokenrouter/anthropic/*` OpenCode runs on the native Anthropic AI SDK provider, matching the solution from #426 / #433.
- Disable Anthropic `toolStreaming` for TokenRouter Claude models so malformed partial streamed tool args are not replayed as string-valued `tool_use.input` blocks.
- Update the TokenRouter Anthropic provider test to assert the model-level option.

## Context
Issue #426 identified the OpenAI-compatible provider path as the cause of `messages: text content blocks must be non-empty` for third-party Claude gateways. The latest failing run is different: TokenRouter's `/v1/messages` endpoint rejects replayed assistant tool-use content because `tool_use.input` is a string instead of an object. The OpenCode log shows this happens after a streamed tool input was recorded as malformed text.

## Tests
- `uv run pytest src/agent/opencode_agent/tests/test_runner.py src/llm/tests/test_routers.py`

## Notes
- I could not run a live TokenRouter scenario from this shell because `TOKENROUTER_BASE_URL` / `TOKENROUTER_API_KEY` are not visible in the environment.