### PR TITLE
Disable FMSR sensor mapping tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ AssetOpsBench is a **unified framework for developing, orchestrating, and evalua
 | MCP Servers | Important tools |
 |---|---|
 | **IoT** | `sites`, `asset_ids`, `asset_detail`, `assets`, `find_assets_by_sensors`, `installed_sensors`, `measured_sensors` |
-| **FMSR** | `get_failure_modes`, `generate_failure_modes`, `add_failure_modes`, `generate_failure_mode_sensor_mapping` |
+| **FMSR** | `get_failure_modes`, `generate_failure_modes`, `add_failure_modes` |
 | **TSFM** | Tasks/evidence: `list_tasks`, `profile_series`, `characterize_series`, `data_quality`; model catalog: `list_models`, `search_models`, `find_models`, `resolve_model`, `model_template`, `register_model`, `register_finetuned`, `hf_stats`; feature catalog: `list_features`, `search_features`, `extract_features`, `select_features`; run/eval ledger: `recipe_template`, `run_recipe`, `run_tabular_recipe`, `run_plan`, `evaluate`, `list_runs`, `list_results` |
 | **WO** | `get_work_order_distribution`, `predict_next_work_order`, ... |
 | **Vibration** | `compute_fft_spectrum`, `compute_envelope_spectrum`, ... |

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -61,7 +61,7 @@ Telemetry windows are half-open ISO 8601 ranges. `history` supports cursor-based
 ## fmsr — Failure Mode and Sensor Relations
 
 **Path:** `src/servers/fmsr/main.py`
-**Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `FAILURE_MODE_DBNAME`) for stored modes; LLM credentials for `generate_failure_modes` and `generate_failure_mode_sensor_mapping`.
+**Requires:** CouchDB (`COUCHDB_URL`, `COUCHDB_USERNAME`, `COUCHDB_PASSWORD`, `FAILURE_MODE_DBNAME`) for stored modes; LLM credentials for `generate_failure_modes`.
 **Failure-mode data:** `src/couchdb/scenarios_data/shared/fmea/failure_modes_sample.json` loaded into the `failure_mode` database collection by default.
 
 | Tool                              | Category      | Arguments                                | Description                                                                                                                                             |
@@ -69,7 +69,6 @@ Telemetry windows are half-open ISO 8601 ranges. `history` supports cursor-based
 | `get_failure_modes`               | read          | `asset_class`                            | Return known failure modes for an asset class from the database. Returns `asset_class`, `failure_modes`, `exhaustive`, and `source`.                    |
 | `generate_failure_modes`          | read, LLM-use | `asset_class`, `max_modes?`              | Generate or extend a failure-mode list without writing the database. |
 | `add_failure_modes`               | write         | `asset_class`, `failure_modes`, `exhaustive?`, `source?` | Persist failure modes for an asset class. |
-| `generate_failure_mode_sensor_mapping` | read, LLM-use | `asset_class`, `failure_modes`, `sensors` | Score failure-mode/sensor relevancy via LLM and return bidirectional mappings. |
 
 ## wo — Work Order
 

--- a/docs/opencode-agent.md
+++ b/docs/opencode-agent.md
@@ -207,14 +207,15 @@ models such as `MiniMax-M3` must be registered explicitly.
 
 ### FMSR tool model
 
-FMSR tools take `asset_class`. `--model-id` controls OpenCode; LLM-backed FMSR
-tools use `FMSR_MODEL_ID`.
+FMSR tools take `asset_class`. `--model-id` controls OpenCode; LLM-backed
+failure-mode generation uses `FMSR_MODEL_ID`. Failure-mode/sensor mapping is not
+registered as an FMSR tool.
 
 ```bash
 MODEL_ID=tokenrouter/MiniMax-M3
 FMSR_MODEL_ID="$MODEL_ID" \
 uv run opencode-agent --model-id "$MODEL_ID" --show-trajectory \
-  "Use generate_failure_mode_sensor_mapping for asset_class pump with failure_modes ['seal leakage'] and sensors ['Pressure sensor']."
+  "Use generate_failure_modes for asset_class pump with max_modes 3."
 ```
 
 ---
@@ -421,12 +422,12 @@ uv run opencode-agent --show-trajectory \
   --model-id tokenrouter/MiniMax-M3 \
   "Use add_failure_modes for asset_class pump with failure_modes ['bearing wear'], exhaustive false, and source 'manual smoke test'. Return added, total, source, and message."
 
-# 8. FMSR mapping smoke test
+# 8. FMSR generation smoke test
 MODEL_ID=tokenrouter/MiniMax-M3
 FMSR_MODEL_ID="$MODEL_ID" \
 uv run opencode-agent --show-trajectory \
   --model-id "$MODEL_ID" \
-  "Use generate_failure_mode_sensor_mapping for asset_class pump with failure_modes ['seal leakage'] and sensors ['Pressure sensor', 'Vibration sensor']."
+  "Use generate_failure_modes for asset_class pump with max_modes 3."
 
 # 9. benchmark-suite dry run
 uv run python -m benchmark.scenario_suite_runner \

--- a/docs/stirrup-agent.md
+++ b/docs/stirrup-agent.md
@@ -99,8 +99,8 @@ asyncio.run(main())
 PY
 ```
 
-Expected default counts: `iot` 12, `utilities` 6, `fmsr` 4, `tsfm` 41, `wo` 15, `vibration` 8
-(86 MCP tools total; the agent additionally has Stirrup's own `finish` tool). If `AOB_READONLY=1`
+Expected default counts: `iot` 12, `utilities` 6, `fmsr` 3, `tsfm` 41, `wo` 15, `vibration` 8
+(85 MCP tools total; the agent additionally has Stirrup's own `finish` tool). If `AOB_READONLY=1`
 is set, `wo` exposes 9 read tools instead of 15.
 
 ---

--- a/src/servers/fmsr/main.py
+++ b/src/servers/fmsr/main.py
@@ -1,13 +1,11 @@
-"""Failure mode and sensor reasoning for industrial asset classes."""
+"""Failure-mode catalog reasoning for industrial asset classes."""
 
 from __future__ import annotations
 
 import logging
 import os
 import re
-from typing import Dict, List, Optional, Union
-
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Optional, Union
 
 import couchdb3
 from couchdb3.exceptions import NotFoundError
@@ -99,12 +97,6 @@ def _is_not_found_error(exc: Exception) -> bool:
 
 # ── Prompt templates ──────────────────────────────────────────────────────────
 
-_RELEVANCY_PROMPT = (
-    "For asset class {asset_class}, if the failure {failure_mode} occurs, "
-    "can sensor {sensor} help monitor or detect the failure for assets of class {asset_class}?\n"
-    "Provide the answer in the first line and reason in the second line."
-)
-
 _FAILURE_MODE_PROMPT = (
     "List up to {max_modes} common failure modes for asset class {asset_class}.\n"
     "Return only failure mode names, one per line."
@@ -128,18 +120,6 @@ def _parse_failure_mode_list(text: str) -> List[str]:
         if item:
             items.append(item)
     return items
-
-
-def _parse_relevancy(text: str) -> dict:
-    lines = [ln for ln in text.strip().splitlines() if ln.strip()]
-    if lines and lines[0].lower().startswith("yes"):
-        answer = "Yes"
-    elif lines and lines[0].lower().startswith("no"):
-        answer = "No"
-    else:
-        answer = "Unknown"
-    reason = lines[1] if len(lines) >= 2 else "Unknown"
-    return {"answer": answer, "reason": reason}
 
 
 # ── LLM backend (lazy init; graceful degradation if creds are absent) ─────────
@@ -182,19 +162,6 @@ except Exception as _e:  # noqa: BLE001
     logger.warning("LLM unavailable (generate_* tools disabled): %s", _e)
     _llm = None
     _llm_available = False
-
-
-def _call_relevancy(asset_class: str, failure_mode: str, sensor: str) -> dict:
-    prompt = _RELEVANCY_PROMPT.format(
-        asset_class=asset_class, failure_mode=failure_mode, sensor=sensor
-    )
-    last_exc: Exception | None = None
-    for _ in range(_MAX_RETRIES):
-        try:
-            return _parse_relevancy(_llm.generate(prompt))
-        except Exception as exc:  # noqa: BLE001
-            last_exc = exc
-    raise last_exc
 
 
 def _call_failure_mode_generation(
@@ -251,32 +218,16 @@ class AddFailureModesResult(BaseModel):
     message: str
 
 
-class RelevancyEntry(BaseModel):
-    asset_class: str
-    failure_mode: str
-    sensor: str
-    relevancy_answer: str
-    relevancy_reason: str
-
-
-class MappingMetadata(BaseModel):
-    asset_class: str
-    failure_modes: List[str]
-    sensors: List[str]
-
-
-class FailureModeSensorMappingResult(BaseModel):
-    metadata: MappingMetadata
-    fm2sensor: Dict[str, List[str]]
-    sensor2fm: Dict[str, List[str]]
-    full_relevancy: List[RelevancyEntry]
-
-
 # ── FastMCP server ────────────────────────────────────────────────────────────
 
 mcp = FastMCP(
     "fmsr",
-    instructions="Failure mode and sensor reasoning for industrial asset classes.",
+    instructions=(
+        "Failure-mode catalog tools for industrial asset classes. Exposes stored "
+        "failure-mode lookup, LLM failure-mode generation, and failure-mode "
+        "persistence. Failure-mode/sensor mapping is intentionally disabled and "
+        "is not available as an FMSR tool."
+    ),
 )
 
 
@@ -489,69 +440,9 @@ def add_failure_modes(
         return ErrorResult(error=str(exc))
 
 
-@mcp.tool(title="Generate Failure Mode Sensor Mapping")
-def generate_failure_mode_sensor_mapping(
-    asset_class: str,
-    failure_modes: List[str],
-    sensors: List[str],
-) -> Union[FailureModeSensorMappingResult, ErrorResult]:
-    """GENERATE, for each (failure_mode, sensor) pair, whether the sensor can detect the failure
-    (one LLM call per pair). Returns a bidirectional mapping (fm→sensors, sensor→fms) plus per-pair
-    relevancy details. Keep both lists small (e.g. ≤5 failure modes, ≤10 sensors) to bound runtime.
-
-    Args:
-        asset_class: Asset class to reason about, such as "pump". Case, whitespace,
-            digits, underscores, and hyphens are normalized before prompting the LLM.
-        failure_modes: Failure modes for the asset class.
-        sensors: Sensor names to evaluate for detection relevance.
-    """
-    key = _asset_class_key(asset_class)
-    if not key or key == "none":
-        return ErrorResult(error="asset_class is required")
-    if not failure_modes:
-        return ErrorResult(error="failure_modes list is required")
-    if not sensors:
-        return ErrorResult(error="sensors list is required")
-    if not _llm_available:
-        return ErrorResult(error="LLM unavailable")
-
-    full_relevancy: List[RelevancyEntry] = []
-    fm2sensor: Dict[str, List[str]] = {}
-    sensor2fm: Dict[str, List[str]] = {}
-    try:
-        pairs = [(s, fm) for s in sensors for fm in failure_modes]
-        with ThreadPoolExecutor() as executor:
-            futures = {
-                executor.submit(_call_relevancy, key, fm, s): (s, fm)
-                for s, fm in pairs
-            }
-            for future in as_completed(futures):
-                s, fm = futures[future]
-                gen = future.result()
-                full_relevancy.append(
-                    RelevancyEntry(
-                        asset_class=key,
-                        failure_mode=fm,
-                        sensor=s,
-                        relevancy_answer=gen["answer"],
-                        relevancy_reason=gen["reason"],
-                    )
-                )
-                if "yes" in gen["answer"].lower():
-                    fm2sensor.setdefault(fm, []).append(s)
-                    sensor2fm.setdefault(s, []).append(fm)
-    except Exception as exc:  # noqa: BLE001
-        logger.error("_call_relevancy failed: %s", exc)
-        return ErrorResult(error=str(exc))
-
-    return FailureModeSensorMappingResult(
-        metadata=MappingMetadata(
-            asset_class=key, failure_modes=failure_modes, sensors=sensors
-        ),
-        fm2sensor=fm2sensor,
-        sensor2fm=sensor2fm,
-        full_relevancy=full_relevancy,
-    )
+# generate_failure_mode_sensor_mapping is intentionally not registered. The
+# mapping workflow is disabled because large failure-mode/sensor matrices make
+# benchmark tool calls too expensive and timeout-prone.
 
 
 def main():

--- a/src/servers/fmsr/main.py
+++ b/src/servers/fmsr/main.py
@@ -226,7 +226,8 @@ mcp = FastMCP(
         "Failure-mode catalog tools for industrial asset classes. Exposes stored "
         "failure-mode lookup, LLM failure-mode generation, and failure-mode "
         "persistence. Failure-mode/sensor mapping is intentionally disabled and "
-        "is not available as an FMSR tool."
+        "is not available as an FMSR tool. Agent should use LLM domain knowledge "
+        "to get mapping by themselves."
     ),
 )
 

--- a/src/servers/fmsr/tests/conftest.py
+++ b/src/servers/fmsr/tests/conftest.py
@@ -102,20 +102,6 @@ def broken_fm_db():
 
 
 @pytest.fixture
-def mock_relevancy_chain():
-    """Patch _call_relevancy so it always returns 'Yes' without calling the LLM."""
-    mock = MagicMock(
-        return_value={
-            "answer": "Yes",
-            "reason": "Relevant sensor",
-        }
-    )
-    with patch("servers.fmsr.main._call_relevancy", mock):
-        with patch("servers.fmsr.main._llm_available", True):
-            yield mock
-
-
-@pytest.fixture
 def mock_failure_mode_generation():
     """Patch failure-mode generation so tests do not call the LLM."""
     mock = MagicMock(

--- a/src/servers/fmsr/tests/test_tools.py
+++ b/src/servers/fmsr/tests/test_tools.py
@@ -285,104 +285,11 @@ class TestAddFailureModes:
         }
 
 
-_FAILURE_MODES = ["Compressor Overheating", "Condenser Water side fouling"]
-_SENSORS = ["Chiller 6 Power Input", "Chiller 6 Supply Temperature"]
-
-
-class TestGenerateFailureModeSensorMapping:
+class TestToolRegistration:
     @pytest.mark.anyio
-    async def test_returns_expected_keys(self, mock_relevancy_chain):
-        data = await call_tool(
-            mcp,
-            "generate_failure_mode_sensor_mapping",
-            {
-                "asset_class": "chiller",
-                "failure_modes": _FAILURE_MODES,
-                "sensors": _SENSORS,
-            },
-        )
+    async def test_mapping_tool_is_not_registered(self):
+        tools = await mcp.list_tools()
 
-        assert "fm2sensor" in data
-        assert "sensor2fm" in data
-        assert "full_relevancy" in data
-        assert data["metadata"]["asset_class"] == "chiller"
-        assert data["full_relevancy"][0]["asset_class"] == "chiller"
-
-    @pytest.mark.anyio
-    async def test_full_relevancy_count(self, mock_relevancy_chain):
-        data = await call_tool(
-            mcp,
-            "generate_failure_mode_sensor_mapping",
-            {
-                "asset_class": "Chiller",
-                "failure_modes": _FAILURE_MODES,
-                "sensors": _SENSORS,
-            },
-        )
-
-        assert len(data["full_relevancy"]) == 4
-
-    @pytest.mark.anyio
-    async def test_empty_failure_modes_returns_error(self, mock_relevancy_chain):
-        data = await call_tool(
-            mcp,
-            "generate_failure_mode_sensor_mapping",
-            {"asset_class": "chiller", "failure_modes": [], "sensors": _SENSORS},
-        )
-
-        assert "error" in data
-
-    @pytest.mark.anyio
-    async def test_empty_asset_class_returns_error(self, mock_relevancy_chain):
-        data = await call_tool(
-            mcp,
-            "generate_failure_mode_sensor_mapping",
-            {
-                "asset_class": "",
-                "failure_modes": _FAILURE_MODES,
-                "sensors": _SENSORS,
-            },
-        )
-
-        assert data == {"error": "asset_class is required"}
-
-    @pytest.mark.anyio
-    async def test_empty_sensors_returns_error(self, mock_relevancy_chain):
-        data = await call_tool(
-            mcp,
-            "generate_failure_mode_sensor_mapping",
-            {"asset_class": "chiller", "failure_modes": _FAILURE_MODES, "sensors": []},
-        )
-
-        assert "error" in data
-
-    @pytest.mark.anyio
-    async def test_llm_unavailable_returns_error(self, no_llm):
-        data = await call_tool(
-            mcp,
-            "generate_failure_mode_sensor_mapping",
-            {
-                "asset_class": "chiller",
-                "failure_modes": _FAILURE_MODES,
-                "sensors": _SENSORS,
-            },
-        )
-
-        assert data == {"error": "LLM unavailable"}
-
-    @requires_watsonx
-    @pytest.mark.anyio
-    async def test_integration(self):
-        data = await call_tool(
-            mcp,
-            "generate_failure_mode_sensor_mapping",
-            {
-                "asset_class": "chiller",
-                "failure_modes": ["Compressor Overheating"],
-                "sensors": ["Chiller 6 Power Input"],
-            },
-        )
-
-        assert "full_relevancy" in data
-        assert len(data["full_relevancy"]) == 1
-        assert data["full_relevancy"][0]["relevancy_answer"] in ("Yes", "No", "Unknown")
+        assert "generate_failure_mode_sensor_mapping" not in {
+            tool.name for tool in tools
+        }


### PR DESCRIPTION
## Summary
- remove the FMSR generate_failure_mode_sensor_mapping MCP tool from the server surface
- update FMSR server instructions and docs to advertise only the remaining three FMSR tools
- replace mapping tests with a registration check that the tool is absent

## Tests
- uv run pytest src/servers/fmsr/tests -q
- uv run pytest src/agent/opencode_agent/tests src/agent/stirrup_agent/tests -q