### PR TITLE
fix(agent): parse single-line fenced JSON in _parse_json

### DIFF
--- a/src/agent/plan_execute/executor.py
+++ b/src/agent/plan_execute/executor.py
@@ -24,6 +24,10 @@ _REPO_ROOT = Path(__file__).parent.parent.parent.parent
 
 _PLACEHOLDER_RE = re.compile(r"\{step_(\d+)\}")
 
+# Matches a ```-fenced block whether the language tag and content share a
+# line with the fence markers or sit on lines of their own.
+_FENCE_RE = re.compile(r"^```[a-zA-Z0-9_+-]*\r?\n?(.*?)\r?\n?```$", re.DOTALL)
+
 _ARG_RESOLUTION_PROMPT = """\
 Generate the JSON arguments for the tool call below.
 
@@ -230,9 +234,9 @@ def _parse_json(raw: str) -> dict | None:
     """
     text = raw.strip()
     if text.startswith("```"):
-        lines = text.splitlines()
-        inner = lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
-        text = "\n".join(inner).lstrip("json").strip()
+        match = _FENCE_RE.match(text)
+        if match:
+            text = match.group(1).strip()
     try:
         result = json.loads(text)
         if isinstance(result, dict):

--- a/src/agent/tests/test_runner.py
+++ b/src/agent/tests/test_runner.py
@@ -580,6 +580,14 @@ def test_parse_json_markdown_fence():
     assert _parse_json('```json\n{"a": "b"}\n```') == {"a": "b"}
 
 
+def test_parse_json_single_line_fence():
+    assert _parse_json('```json{"site": "MAIN"}```') == {"site": "MAIN"}
+
+
+def test_parse_json_single_line_fence_no_language_tag():
+    assert _parse_json('```{"site": "MAIN"}```') == {"site": "MAIN"}
+
+
 def test_parse_json_embedded():
     assert _parse_json('Result: {"a": "b"} done.') == {"a": "b"}
 


### PR DESCRIPTION
`_parse_json` split a fenced response on newlines to strip the ```` ``` ```` code fence:

```python
lines = text.splitlines()
inner = lines[1:-1] if lines[-1].strip() == "```" else lines[1:]
text = "\n".join(inner).lstrip("json").strip()
```

When the opening fence, language tag, and JSON share one line (e.g. `` ```json{"site": "MAIN"}``` ``, no internal newline), `text.splitlines()` returns a single-element list. `lines[-1].strip() == "```"` is then false, so `inner = lines[1:]` is `[]`, and `text` becomes an empty string before `json.loads` or the brace-scanning fallback ever run. Valid JSON is discarded and `_parse_json` returns `None`; the caller (`_resolve_args_with_llm`) treats that as unparseable and calls the tool with no arguments instead of the arguments the LLM produced.

Replaced the split/join with a single regex that matches the fence and optional language tag whether or not they share a line with the payload, so both layouts extract the same content.

## Verified

Docker (`python:3.12-slim`, editable install, `python3 -c 'import agent.plan_execute.executor as m; print(m.__file__)'` confirmed the real repo module, not a stale install):

- `pytest src/agent/tests/` on this branch: 74 passed, including the two new regression tests.
- Reverting only `executor.py` to HEAD (`e5dc83b`) while keeping the new tests: `pytest -k single_line_fence` fails with `assert None == {'site': 'MAIN'}` on both, confirming they fail on main and pass on the fix.
- `ruff check` / `ruff format --check` on both changed files: clean. The 6 pre-existing `ruff check` findings elsewhere in `executor.py` (import order, an undefined forward-ref type, two `SIM117` nested-`with` suggestions, and a `removeprefix` suggestion in the unrelated `_parse_tool_call` helper) are unchanged from HEAD and outside this diff's scope.

Not touched: `_parse_tool_call` a few lines below has the same fence-splitting shape and would show the same bug on a single-line input, but its own docstring says it's "utility, not used in main path," so it isn't part of this fix.

Fixes #482
