### PR TITLE
Fix routed model handling for SDK agents

### DIFF
--- a/src/agent/claude_agent/cli.py
+++ b/src/agent/claude_agent/cli.py
@@ -10,6 +10,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import sys
 
 from .._cli_common import add_common_args, print_result, run_sdk_cli
 
@@ -25,7 +26,7 @@ def _build_parser() -> argparse.ArgumentParser:
 environment variables:
   LITELLM_API_KEY       LiteLLM / Anthropic API key (for litellm_proxy/* models)
   LITELLM_BASE_URL      LiteLLM proxy URL (required for litellm_proxy/* models)
-  TOKENROUTER_API_KEY   TokenRouter API key (for tokenrouter/* models)
+  TOKENROUTER_API_KEY   TokenRouter API key (Claude/Anthropic models only)
   TOKENROUTER_BASE_URL  TokenRouter base URL (Anthropic-compatible endpoint)
 
 examples:
@@ -48,10 +49,18 @@ examples:
 
 
 async def _run(args: argparse.Namespace) -> None:
-    from agent.claude_agent.runner import ClaudeAgentRunner
+    from agent.claude_agent.runner import (
+        ClaudeAgentConfigurationError,
+        ClaudeAgentError,
+        ClaudeAgentRunner,
+    )
 
-    runner = ClaudeAgentRunner(model=args.model_id, max_turns=args.max_turns)
-    result = await runner.run(args.question)
+    try:
+        runner = ClaudeAgentRunner(model=args.model_id, max_turns=args.max_turns)
+        result = await runner.run(args.question)
+    except (ClaudeAgentConfigurationError, ClaudeAgentError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        sys.exit(1)
     print_result(
         result, show_trajectory=args.show_trajectory, output_json=args.output_json
     )

--- a/src/agent/claude_agent/runner.py
+++ b/src/agent/claude_agent/runner.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import datetime as _dt
 import logging
 import time
+from collections import deque
 from pathlib import Path
 
 from claude_agent_sdk import (
@@ -39,6 +40,37 @@ from ..runner import AgentRunner
 _log = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "litellm_proxy/aws/claude-opus-4-6"
+_TOKENROUTER_ANTHROPIC_PREFIX = "tokenrouter/anthropic/"
+_TOKENROUTER_OPENAI_PREFIX = "tokenrouter/openai/"
+_ERROR_STREAM_TAIL_CHARS = 4000
+_STDERR_MAX_LINES = 200
+
+
+class ClaudeAgentError(RuntimeError):
+    """Raised when the Claude Code SDK subprocess reports a run failure."""
+
+
+class ClaudeAgentConfigurationError(ValueError):
+    """Raised when a requested model cannot be driven by claude-agent."""
+
+
+def _validate_model_id(model_id: str) -> None:
+    """Reject model IDs known to be incompatible with Claude Code."""
+    if model_id.startswith(_TOKENROUTER_ANTHROPIC_PREFIX):
+        raise ClaudeAgentConfigurationError(
+            "claude-agent is backed by Claude Code, which rejects "
+            f"provider-prefixed TokenRouter model IDs like {model_id!r}. "
+            "Use openai-agent or opencode-agent for TokenRouter Anthropic "
+            "models, e.g. "
+            f"uv run openai-agent --model-id {model_id!r} \"hello\"."
+        )
+    if model_id.startswith(_TOKENROUTER_OPENAI_PREFIX):
+        raise ClaudeAgentConfigurationError(
+            "claude-agent is backed by Claude Code and cannot run "
+            f"{model_id!r}. Use openai-agent or opencode-agent for "
+            "TokenRouter OpenAI models, e.g. "
+            f"uv run openai-agent --model-id {model_id!r} \"hello\"."
+        )
 
 
 def _sdk_env(model_id: str) -> dict[str, str] | None:
@@ -57,6 +89,31 @@ def _sdk_env(model_id: str) -> dict[str, str] | None:
         "ANTHROPIC_BASE_URL": creds.base_url,
         "ANTHROPIC_API_KEY": creds.api_key,
     }
+
+
+def _tail_text(text: str, limit: int = _ERROR_STREAM_TAIL_CHARS) -> str:
+    """Return a compact suffix of *text* for user-facing error messages."""
+    if len(text) <= limit:
+        return text
+    return "..." + text[-limit:]
+
+
+def _format_sdk_failure(
+    exc: Exception,
+    *,
+    result_error: str | None,
+    stderr_lines: deque[str],
+) -> str:
+    """Build a useful error from the SDK exception plus captured CLI output."""
+    parts = ["Claude Code CLI failed."]
+    if result_error:
+        parts.append(f"Result error: {result_error}")
+    stderr = "\n".join(stderr_lines).strip()
+    if stderr:
+        parts.append(f"stderr tail:\n{_tail_text(stderr)}")
+    elif not result_error:
+        parts.append(str(exc))
+    return "\n".join(parts)
 
 
 def _build_mcp_servers(
@@ -102,6 +159,7 @@ class ClaudeAgentRunner(AgentRunner):
         max_turns: int = 30,
         permission_mode: str = "bypassPermissions",
     ) -> None:
+        _validate_model_id(model)
         super().__init__(llm, server_paths)
         self._model = resolve_model(model)
         self._sdk_env = _sdk_env(model)
@@ -121,13 +179,19 @@ class ClaudeAgentRunner(AgentRunner):
         with agent_run_span(
             "claude-agent", model=self._model, question=question
         ) as span:
+            stderr_lines: deque[str] = deque(maxlen=_STDERR_MAX_LINES)
+
+            def _capture_stderr(line: str) -> None:
+                stderr_lines.append(line)
+
             options = ClaudeAgentOptions(
                 model=self._model,
                 system_prompt=AGENT_SYSTEM_PROMPT,
                 mcp_servers=self._mcp_servers,
                 max_turns=self._max_turns,
                 permission_mode=self._permission_mode,
-                env=self._sdk_env,
+                env=self._sdk_env or {},
+                stderr=_capture_stderr,
             )
 
             _log.info("ClaudeAgentRunner: starting query (model=%s)", self._model)
@@ -137,6 +201,7 @@ class ClaudeAgentRunner(AgentRunner):
             turn_index = 0
             last_turn_start = run_started
             tool_outputs: dict[str, object] = {}
+            result_error: str | None = None
 
             async def _capture_tool_output(
                 input_data, tool_use_id: str, context
@@ -170,46 +235,74 @@ class ClaudeAgentRunner(AgentRunner):
                     if tc.id in tool_outputs:
                         tc.output = tool_outputs.pop(tc.id)
 
-            async for message in query(prompt=question, options=options):
-                if isinstance(message, AssistantMessage):
-                    _flush_tool_outputs()
-                    now = time.perf_counter()
-                    turn_duration_ms = (now - last_turn_start) * 1000
-                    last_turn_start = now
-                    text = ""
-                    tool_calls: list[ToolCall] = []
-                    for block in message.content:
-                        if isinstance(block, TextBlock):
-                            text += block.text
-                        elif isinstance(block, ToolUseBlock):
-                            tool_calls.append(
-                                ToolCall(
-                                    name=block.name, input=block.input, id=block.id
+            try:
+                async for message in query(prompt=question, options=options):
+                    if isinstance(message, AssistantMessage):
+                        _flush_tool_outputs()
+                        now = time.perf_counter()
+                        turn_duration_ms = (now - last_turn_start) * 1000
+                        last_turn_start = now
+                        text = ""
+                        tool_calls: list[ToolCall] = []
+                        for block in message.content:
+                            if isinstance(block, TextBlock):
+                                text += block.text
+                            elif isinstance(block, ToolUseBlock):
+                                tool_calls.append(
+                                    ToolCall(
+                                        name=block.name, input=block.input, id=block.id
+                                    )
                                 )
+                        usage = message.usage or {}
+                        trajectory.turns.append(
+                            TurnRecord(
+                                index=turn_index,
+                                text=text,
+                                tool_calls=tool_calls,
+                                input_tokens=usage.get("input_tokens", 0),
+                                output_tokens=usage.get("output_tokens", 0),
+                                duration_ms=turn_duration_ms,
                             )
-                    usage = message.usage or {}
-                    trajectory.turns.append(
-                        TurnRecord(
-                            index=turn_index,
-                            text=text,
-                            tool_calls=tool_calls,
-                            input_tokens=usage.get("input_tokens", 0),
-                            output_tokens=usage.get("output_tokens", 0),
-                            duration_ms=turn_duration_ms,
                         )
+                        turn_index += 1
+                    elif isinstance(message, ResultMessage):
+                        _flush_tool_outputs()
+                        answer = message.result or ""
+                        if message.is_error:
+                            result_error = (
+                                message.result
+                                or (
+                                    "; ".join(message.errors)
+                                    if message.errors
+                                    else None
+                                )
+                                or "Claude Code returned an error result."
+                            )
+                        _log.info(
+                            "ClaudeAgentRunner: done (stop_reason=%s, turns=%d, "
+                            "input_tokens=%d, output_tokens=%d)",
+                            message.stop_reason,
+                            len(trajectory.turns),
+                            trajectory.total_input_tokens,
+                            trajectory.total_output_tokens,
+                        )
+            except Exception as exc:
+                raise ClaudeAgentError(
+                    _format_sdk_failure(
+                        exc,
+                        result_error=result_error,
+                        stderr_lines=stderr_lines,
                     )
-                    turn_index += 1
-                elif isinstance(message, ResultMessage):
-                    _flush_tool_outputs()
-                    answer = message.result or ""
-                    _log.info(
-                        "ClaudeAgentRunner: done (stop_reason=%s, turns=%d, "
-                        "input_tokens=%d, output_tokens=%d)",
-                        message.stop_reason,
-                        len(trajectory.turns),
-                        trajectory.total_input_tokens,
-                        trajectory.total_output_tokens,
+                ) from exc
+
+            if result_error:
+                raise ClaudeAgentError(
+                    _format_sdk_failure(
+                        RuntimeError(result_error),
+                        result_error=result_error,
+                        stderr_lines=stderr_lines,
                     )
+                )
 
             duration_ms = (time.perf_counter() - run_started) * 1000
             span.set_attribute("agent.answer.length", len(answer))

--- a/src/agent/claude_agent/tests/test_runner.py
+++ b/src/agent/claude_agent/tests/test_runner.py
@@ -10,13 +10,29 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from agent.claude_agent.runner import ClaudeAgentRunner, _build_mcp_servers, _sdk_env
+from agent.claude_agent.runner import (
+    ClaudeAgentConfigurationError,
+    ClaudeAgentError,
+    ClaudeAgentRunner,
+    _build_mcp_servers,
+    _sdk_env,
+)
 from agent.models import AgentResult, Trajectory
 
 
 def test_resolve_model_stored_on_runner():
     runner = ClaudeAgentRunner(model="litellm_proxy/aws/claude-opus-4-6")
     assert runner._model == "aws/claude-opus-4-6"
+
+
+def test_rejects_tokenrouter_openai_models():
+    with pytest.raises(ClaudeAgentConfigurationError, match="openai-agent"):
+        ClaudeAgentRunner(model="tokenrouter/openai/gpt-5.6-sol")
+
+
+def test_rejects_tokenrouter_anthropic_provider_models():
+    with pytest.raises(ClaudeAgentConfigurationError, match="TokenRouter Anthropic"):
+        ClaudeAgentRunner(model="tokenrouter/anthropic/claude-opus-4.8")
 
 
 def test_sdk_env_no_prefix_returns_none():
@@ -95,6 +111,7 @@ async def test_run_returns_orchestrator_result():
     mock_result = MagicMock(spec=ResultMessage)
     mock_result.result = "42 sensors found"
     mock_result.stop_reason = "end_turn"
+    mock_result.is_error = False
 
     async def fake_query(prompt, options):
         yield mock_result
@@ -109,6 +126,62 @@ async def test_run_returns_orchestrator_result():
     assert isinstance(result.trajectory, Trajectory)
     assert result.trajectory.total_input_tokens == 0
     assert result.trajectory.total_output_tokens == 0
+
+
+@pytest.mark.anyio
+async def test_run_uses_empty_env_for_unproxied_model():
+    from claude_agent_sdk import ResultMessage
+
+    captured = {}
+    mock_result = MagicMock(spec=ResultMessage)
+    mock_result.result = "ok"
+    mock_result.stop_reason = "end_turn"
+    mock_result.is_error = False
+
+    async def fake_query(prompt, options):
+        captured["env"] = options.env
+        captured["stderr"] = options.stderr
+        yield mock_result
+
+    with patch("agent.claude_agent.runner.query", side_effect=fake_query):
+        runner = ClaudeAgentRunner(server_paths={}, model="claude-opus-4-6")
+        result = await runner.run("hello")
+
+    assert result.answer == "ok"
+    assert captured["env"] == {}
+    assert callable(captured["stderr"])
+
+
+@pytest.mark.anyio
+async def test_run_raises_on_sdk_error_result():
+    from claude_agent_sdk import ResultMessage
+
+    mock_result = MagicMock(spec=ResultMessage)
+    mock_result.result = "selected model is invalid"
+    mock_result.stop_reason = "stop_sequence"
+    mock_result.is_error = True
+    mock_result.errors = None
+
+    async def fake_query(prompt, options):
+        yield mock_result
+
+    with patch("agent.claude_agent.runner.query", side_effect=fake_query):
+        runner = ClaudeAgentRunner(server_paths={})
+        with pytest.raises(ClaudeAgentError, match="selected model is invalid"):
+            await runner.run("hello")
+
+
+@pytest.mark.anyio
+async def test_run_includes_captured_stderr_on_sdk_exception():
+    async def fake_query(prompt, options):
+        options.stderr("diagnostic stderr")
+        raise RuntimeError("sdk wrapper failure")
+        yield  # make it an async generator
+
+    with patch("agent.claude_agent.runner.query", side_effect=fake_query):
+        runner = ClaudeAgentRunner(server_paths={})
+        with pytest.raises(ClaudeAgentError, match="diagnostic stderr"):
+            await runner.run("hello")
 
 
 @pytest.mark.anyio
@@ -135,6 +208,7 @@ async def test_run_collects_trajectory():
     mock_result = MagicMock(spec=ResultMessage)
     mock_result.result = "Chiller 6 has 5 sensors."
     mock_result.stop_reason = "end_turn"
+    mock_result.is_error = False
 
     async def fake_query(prompt, options):
         yield mock_assistant
@@ -188,6 +262,7 @@ async def test_run_tool_output_captured():
     mock_result = MagicMock(spec=ResultMessage)
     mock_result.result = "5 sensors."
     mock_result.stop_reason = "end_turn"
+    mock_result.is_error = False
 
     async def fake_query(prompt, options):
         # Simulate hook firing between turns by calling it directly
@@ -235,6 +310,7 @@ async def test_run_tool_output_string_response():
     mock_result = MagicMock(spec=ResultMessage)
     mock_result.result = "MAIN"
     mock_result.stop_reason = "end_turn"
+    mock_result.is_error = False
 
     async def fake_query(prompt, options):
         hook_fn = options.hooks["PostToolUse"][0].hooks[0]

--- a/src/agent/openai_agent/runner.py
+++ b/src/agent/openai_agent/runner.py
@@ -26,6 +26,7 @@ from openai import AsyncOpenAI
 
 from agents import (
     Agent,
+    ModelSettings,
     ModelProvider,
     OpenAIChatCompletionsModel,
     RunConfig,
@@ -33,6 +34,7 @@ from agents import (
     set_tracing_disabled,
 )
 from agents.mcp import MCPServerStdio
+from openai.types.shared import Reasoning
 
 from observability import agent_run_span, persist_trajectory
 
@@ -44,6 +46,21 @@ from ..runner import AgentRunner
 _log = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "litellm_proxy/azure/gpt-5.4"
+_TOKENROUTER_OPENAI_GPT5_PREFIX = "tokenrouter/openai/gpt-5"
+
+
+def _needs_reasoning_effort_none(model_id: str) -> bool:
+    """Whether this router model requires reasoning_effort=none with tools."""
+    return model_id.startswith(_TOKENROUTER_OPENAI_GPT5_PREFIX)
+
+
+def _build_model_settings(model_id: str) -> ModelSettings:
+    """Build per-model settings for OpenAI-compatible chat completions."""
+    if _needs_reasoning_effort_none(model_id):
+        # TokenRouter rejects function tools for OpenAI GPT-5 models on
+        # /v1/chat/completions unless reasoning_effort is explicitly disabled.
+        return ModelSettings(reasoning=Reasoning(effort="none"))
+    return ModelSettings()
 
 
 def _build_run_config(model_id: str) -> RunConfig | None:
@@ -200,6 +217,7 @@ class OpenAIAgentRunner(AgentRunner):
         self._model_id = model
         self._model = resolve_model(model)
         self._run_config = _build_run_config(model)
+        self._model_settings = _build_model_settings(model)
         self._max_turns = max_turns
 
     async def run(self, question: str) -> AgentResult:
@@ -229,6 +247,7 @@ class OpenAIAgentRunner(AgentRunner):
                     instructions=AGENT_SYSTEM_PROMPT,
                     mcp_servers=active_servers,
                     model=self._model,
+                    model_settings=self._model_settings,
                 )
 
                 _log.info(

--- a/src/agent/openai_agent/tests/test_runner.py
+++ b/src/agent/openai_agent/tests/test_runner.py
@@ -14,8 +14,10 @@ import pytest
 from agent.openai_agent.runner import (
     OpenAIAgentRunner,
     _build_mcp_servers,
+    _build_model_settings,
     _build_run_config,
     _build_trajectory,
+    _needs_reasoning_effort_none,
 )
 from agent.models import AgentResult, Trajectory
 
@@ -69,6 +71,29 @@ def test_build_run_config_missing_env_raises(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# _build_model_settings
+# ---------------------------------------------------------------------------
+
+
+def test_tokenrouter_gpt5_models_need_reasoning_effort_none():
+    assert _needs_reasoning_effort_none("tokenrouter/openai/gpt-5.6-sol")
+    assert _needs_reasoning_effort_none("tokenrouter/openai/gpt-5.4")
+    assert not _needs_reasoning_effort_none("tokenrouter/MiniMax-M3")
+    assert not _needs_reasoning_effort_none("litellm_proxy/openai/gpt-5.6-sol")
+
+
+def test_build_model_settings_tokenrouter_gpt5_reasoning_none():
+    settings = _build_model_settings("tokenrouter/openai/gpt-5.6-sol")
+    assert settings.reasoning is not None
+    assert settings.reasoning.effort == "none"
+
+
+def test_build_model_settings_default_empty():
+    settings = _build_model_settings("tokenrouter/MiniMax-M3")
+    assert settings.reasoning is None
+
+
+# ---------------------------------------------------------------------------
 # OpenAIAgentRunner.__init__
 # ---------------------------------------------------------------------------
 
@@ -102,6 +127,16 @@ def test_runner_litellm_model(monkeypatch):
     runner = OpenAIAgentRunner(model="litellm_proxy/Azure/gpt-5-2025-08-07")
     assert runner._model == "Azure/gpt-5-2025-08-07"
     assert runner._run_config is not None
+
+
+def test_runner_tokenrouter_gpt5_model_settings(monkeypatch):
+    monkeypatch.setenv("TOKENROUTER_BASE_URL", "http://localhost:4000/v1")
+    monkeypatch.setenv("TOKENROUTER_API_KEY", "sk-test")
+    runner = OpenAIAgentRunner(model="tokenrouter/openai/gpt-5.6-sol")
+    assert runner._model == "openai/gpt-5.6-sol"
+    assert runner._run_config is not None
+    assert runner._model_settings.reasoning is not None
+    assert runner._model_settings.reasoning.effort == "none"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- fail fast in claude-agent for TokenRouter provider-prefixed OpenAI and Anthropic model IDs that Claude Code rejects locally
- preserve Claude Code structured error results and captured stderr when the SDK subprocess fails
- set reasoning_effort=none for tokenrouter/openai/gpt-5* in openai-agent chat-completions runs with tools

## Verification
- uv run pytest src/agent/claude_agent/tests/test_runner.py src/agent/openai_agent/tests/test_runner.py -q
- uv run python -m py_compile src/agent/claude_agent/runner.py src/agent/claude_agent/tests/test_runner.py src/agent/openai_agent/runner.py src/agent/openai_agent/tests/test_runner.py
- uv run openai-agent --model-id tokenrouter/openai/gpt-5.6-sol --show-trajectory "hello"
- uv run claude-agent --model-id tokenrouter/anthropic/claude-opus-4.8 --show-trajectory "hello"