### PR TITLE
Update OpenAI Agents and TokenRouter Responses routing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "litellm==1.81.13",
     "openai>=1.40.0",
     "claude-agent-sdk>=0.0.14",
-    "openai-agents>=0.0.7",
+    "openai-agents>=0.18.3",
     "deepagents>=0.5.3",
     "langchain-mcp-adapters>=0.2.2",
     "langchain-openai>=1.1.0",

--- a/src/agent/openai_agent/cli.py
+++ b/src/agent/openai_agent/cli.py
@@ -24,6 +24,7 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog="""
 model-id format:
   litellm_proxy/<model>   LiteLLM proxy (e.g. litellm_proxy/azure/gpt-5.4)
+  tokenrouter/<model>     TokenRouter Responses API (e.g. tokenrouter/MiniMax-M3)
 
 environment variables:
   LITELLM_API_KEY       LiteLLM API key    (required)

--- a/src/agent/openai_agent/runner.py
+++ b/src/agent/openai_agent/runner.py
@@ -31,7 +31,6 @@ from agents import (
     OpenAIProvider,
     RunConfig,
     Runner,
-    set_tracing_disabled,
 )
 from agents.mcp import MCPServerStdio
 
@@ -64,14 +63,14 @@ def _build_run_config(model_id: str) -> RunConfig | None:
 
     resolved = resolve_model(model_id)
     client = AsyncOpenAI(base_url=creds.base_url, api_key=creds.api_key)
-    set_tracing_disabled(disabled=True)
 
     if creds.prefix == TOKENROUTER_PREFIX:
         return RunConfig(
             model_provider=OpenAIProvider(
                 openai_client=client,
                 use_responses=True,
-            )
+            ),
+            tracing_disabled=True,
         )
 
     class _ChatCompletionsModelProvider(ModelProvider):
@@ -81,7 +80,10 @@ def _build_run_config(model_id: str) -> RunConfig | None:
                 openai_client=client,
             )
 
-    return RunConfig(model_provider=_ChatCompletionsModelProvider())
+    return RunConfig(
+        model_provider=_ChatCompletionsModelProvider(),
+        tracing_disabled=True,
+    )
 
 
 def _build_mcp_servers(
@@ -109,19 +111,103 @@ def _build_mcp_servers(
     return servers
 
 
-def _build_trajectory(result) -> Trajectory:
+def _item_value(item, name: str, default=None):
+    if isinstance(item, dict):
+        return item.get(name, default)
+    return getattr(item, name, default)
+
+
+def _tool_call_id(raw_item) -> str:
+    return (_item_value(raw_item, "call_id", "") or _item_value(raw_item, "id", ""))
+
+
+def _tool_call_from_raw(raw_item) -> ToolCall:
+    tc_args = _item_value(raw_item, "arguments", "{}") or "{}"
+    try:
+        tc_input = json.loads(tc_args) if isinstance(tc_args, str) else tc_args
+    except (json.JSONDecodeError, TypeError):
+        tc_input = {"raw": tc_args}
+    return ToolCall(
+        name=_item_value(raw_item, "name", "") or "",
+        input=tc_input,
+        id=_tool_call_id(raw_item),
+    )
+
+
+def _message_text(raw_item) -> str:
+    text_parts: list[str] = []
+    for part in _item_value(raw_item, "content", None) or []:
+        text = _item_value(part, "text", None)
+        if text:
+            text_parts.append(text)
+    return "".join(text_parts)
+
+
+def _collect_tool_calls(result) -> dict[str, ToolCall]:
+    calls_by_id: dict[str, ToolCall] = {}
+    for item in getattr(result, "new_items", []) or []:
+        if getattr(item, "type", "") != "tool_call_item":
+            continue
+        raw_item = getattr(item, "raw_item", None)
+        if raw_item is None:
+            continue
+        tool_call = _tool_call_from_raw(raw_item)
+        if tool_call.id:
+            calls_by_id[tool_call.id] = tool_call
+
+    for item in getattr(result, "new_items", []) or []:
+        if getattr(item, "type", "") != "tool_call_output_item":
+            continue
+        raw_item = getattr(item, "raw_item", None)
+        call_id = _tool_call_id(raw_item)
+        if call_id in calls_by_id:
+            calls_by_id[call_id].output = getattr(item, "output", None)
+
+    return calls_by_id
+
+
+def _build_trajectory_from_responses(result, raw_responses) -> Trajectory:
+    trajectory = Trajectory()
+    calls_by_id = _collect_tool_calls(result)
+
+    for index, response in enumerate(raw_responses):
+        text_parts: list[str] = []
+        tool_calls: list[ToolCall] = []
+        for raw_item in getattr(response, "output", None) or []:
+            if _item_value(raw_item, "type", "") == "message":
+                text_parts.append(_message_text(raw_item))
+            call_id = _tool_call_id(raw_item)
+            if call_id in calls_by_id:
+                tool_calls.append(calls_by_id[call_id])
+
+        usage = getattr(response, "usage", None)
+        trajectory.turns.append(
+            TurnRecord(
+                index=index,
+                text="".join(text_parts),
+                tool_calls=tool_calls,
+                input_tokens=getattr(usage, "input_tokens", 0) or 0,
+                output_tokens=getattr(usage, "output_tokens", 0) or 0,
+            )
+        )
+
+    return trajectory
+
+
+def _build_trajectory_from_items(result, raw_responses) -> Trajectory:
     """Extract a Trajectory from a Runner.run result.
 
-    Walks ``result.new_items`` to collect text messages, tool calls, and
-    tool outputs.  Token usage is pulled from ``result.raw_responses``.
+    Fallback for mocked or legacy results whose raw responses do not expose
+    their output items.
     """
     trajectory = Trajectory()
     turn_index = 0
     text_parts: list[str] = []
     tool_calls: list[ToolCall] = []
+    tool_calls_by_id: dict[str, ToolCall] = {}
 
     def _flush() -> None:
-        nonlocal text_parts, tool_calls, turn_index
+        nonlocal text_parts, tool_calls, tool_calls_by_id, turn_index
         if not text_parts and not tool_calls:
             return
         trajectory.turns.append(
@@ -134,6 +220,7 @@ def _build_trajectory(result) -> Trajectory:
         turn_index += 1
         text_parts = []
         tool_calls = []
+        tool_calls_by_id = {}
 
     for item in result.new_items:
         item_type = getattr(item, "type", "")
@@ -149,34 +236,43 @@ def _build_trajectory(result) -> Trajectory:
         elif item_type == "tool_call_item":
             raw = getattr(item, "raw_item", None)
             if raw:
-                tc_name = getattr(raw, "name", "") or ""
-                tc_id = getattr(raw, "call_id", "") or getattr(raw, "id", "") or ""
-                tc_args = getattr(raw, "arguments", "{}") or "{}"
-                try:
-                    tc_input = (
-                        json.loads(tc_args) if isinstance(tc_args, str) else tc_args
-                    )
-                except (json.JSONDecodeError, TypeError):
-                    tc_input = {"raw": tc_args}
-                tool_calls.append(ToolCall(name=tc_name, input=tc_input, id=tc_id))
+                tool_call = _tool_call_from_raw(raw)
+                tool_calls.append(tool_call)
+                if tool_call.id:
+                    tool_calls_by_id[tool_call.id] = tool_call
         elif item_type == "tool_call_output_item":
             output = getattr(item, "output", None)
-            # Attach output to the last matching tool call
-            if tool_calls:
-                tool_calls[-1].output = output
+            call_id = _tool_call_id(getattr(item, "raw_item", None))
+            matching_call = tool_calls_by_id.get(call_id)
+            if matching_call is None:
+                matching_call = next(
+                    (call for call in reversed(tool_calls) if call.output is None), None
+                )
+            if matching_call is not None:
+                matching_call.output = output
 
     # Flush remaining
     _flush()
 
     # Distribute token usage from raw_responses across turns
-    raw_responses = getattr(result, "raw_responses", []) or []
     for i, resp in enumerate(raw_responses):
         usage = getattr(resp, "usage", None)
-        if usage and i < len(trajectory.turns):
-            trajectory.turns[i].input_tokens = getattr(usage, "input_tokens", 0) or 0
-            trajectory.turns[i].output_tokens = getattr(usage, "output_tokens", 0) or 0
+        if not usage:
+            continue
+        if i >= len(trajectory.turns):
+            trajectory.turns.append(TurnRecord(index=i, text=""))
+        trajectory.turns[i].input_tokens = getattr(usage, "input_tokens", 0) or 0
+        trajectory.turns[i].output_tokens = getattr(usage, "output_tokens", 0) or 0
 
     return trajectory
+
+
+def _build_trajectory(result) -> Trajectory:
+    """Extract text, tool calls, tool outputs, and usage from a run result."""
+    raw_responses = getattr(result, "raw_responses", []) or []
+    if raw_responses and all(hasattr(response, "output") for response in raw_responses):
+        return _build_trajectory_from_responses(result, raw_responses)
+    return _build_trajectory_from_items(result, raw_responses)
 
 
 class OpenAIAgentRunner(AgentRunner):
@@ -185,17 +281,16 @@ class OpenAIAgentRunner(AgentRunner):
     The SDK handles tool discovery, invocation, and multi-turn conversation
     against the registered MCP servers.
 
-    Routes all requests through a LiteLLM proxy via the ``litellm_proxy/``
-    proxy-router prefix ``litellm_proxy/`` or ``tokenrouter/`` (requires the
-    matching ``*_BASE_URL`` / ``*_API_KEY`` env vars).
+    Routes prefixed models through either LiteLLM or TokenRouter using the
+    matching ``*_BASE_URL`` / ``*_API_KEY`` environment variables.
 
     Args:
         llm: Unused — OpenAIAgentRunner uses the OpenAI Agents SDK directly.
              Accepted for interface compatibility with ``AgentRunner``.
         server_paths: MCP server specs identical to ``PlanExecuteRunner``.
                       Defaults to all registered servers.
-        model: LiteLLM model string with ``litellm_proxy/`` prefix
-               (default: ``litellm_proxy/azure/gpt-5.4``).
+        model: Direct model ID or a ``litellm_proxy/`` / ``tokenrouter/``
+               model ID (default: ``litellm_proxy/azure/gpt-5.4``).
         max_turns: Maximum agentic loop turns (default: 30).
     """
 

--- a/src/agent/openai_agent/runner.py
+++ b/src/agent/openai_agent/runner.py
@@ -45,7 +45,6 @@ from ..runner import AgentRunner
 _log = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "litellm_proxy/azure/gpt-5.4"
-_TOKENROUTER_OPENAI_PREFIX = f"{TOKENROUTER_PREFIX}openai/"
 
 
 def _build_run_config(model_id: str) -> RunConfig | None:
@@ -54,8 +53,8 @@ def _build_run_config(model_id: str) -> RunConfig | None:
     When *model_id* starts with a proxy-router prefix (``litellm_proxy/`` or
     ``tokenrouter/``), creates an :class:`AsyncOpenAI` client pointing at that
     router's OpenAI-compatible endpoint using credentials from the router's
-    environment variables. OpenAI models routed through TokenRouter use the
-    Responses API; other routed models use Chat Completions.
+    environment variables. All models routed through TokenRouter use the
+    Responses API; LiteLLM models use Chat Completions.
 
     Returns ``None`` for direct OpenAI API usage.
     """
@@ -67,7 +66,7 @@ def _build_run_config(model_id: str) -> RunConfig | None:
     client = AsyncOpenAI(base_url=creds.base_url, api_key=creds.api_key)
     set_tracing_disabled(disabled=True)
 
-    if model_id.startswith(_TOKENROUTER_OPENAI_PREFIX):
+    if creds.prefix == TOKENROUTER_PREFIX:
         return RunConfig(
             model_provider=OpenAIProvider(
                 openai_client=client,

--- a/src/agent/openai_agent/runner.py
+++ b/src/agent/openai_agent/runner.py
@@ -28,6 +28,7 @@ from agents import (
     Agent,
     ModelProvider,
     OpenAIChatCompletionsModel,
+    OpenAIProvider,
     RunConfig,
     Runner,
     set_tracing_disabled,
@@ -36,7 +37,7 @@ from agents.mcp import MCPServerStdio
 
 from observability import agent_run_span, persist_trajectory
 
-from llm.routers import resolve_model, resolve_router_creds
+from llm.routers import TOKENROUTER_PREFIX, resolve_model, resolve_router_creds
 from .._prompts import AGENT_SYSTEM_PROMPT
 from ..models import AgentResult, ToolCall, Trajectory, TurnRecord
 from ..runner import AgentRunner
@@ -44,15 +45,17 @@ from ..runner import AgentRunner
 _log = logging.getLogger(__name__)
 
 _DEFAULT_MODEL = "litellm_proxy/azure/gpt-5.4"
+_TOKENROUTER_OPENAI_PREFIX = f"{TOKENROUTER_PREFIX}openai/"
 
 
 def _build_run_config(model_id: str) -> RunConfig | None:
-    """Build a RunConfig with a LiteLLM model provider when needed.
+    """Build a RunConfig with a router-specific model provider when needed.
 
     When *model_id* starts with a proxy-router prefix (``litellm_proxy/`` or
     ``tokenrouter/``), creates an :class:`AsyncOpenAI` client pointing at that
-    router's OpenAI-compatible endpoint (credentials from the router's env
-    vars) and wraps it in :class:`OpenAIChatCompletionsModel`.
+    router's OpenAI-compatible endpoint using credentials from the router's
+    environment variables. OpenAI models routed through TokenRouter use the
+    Responses API; other routed models use Chat Completions.
 
     Returns ``None`` for direct OpenAI API usage.
     """
@@ -64,14 +67,22 @@ def _build_run_config(model_id: str) -> RunConfig | None:
     client = AsyncOpenAI(base_url=creds.base_url, api_key=creds.api_key)
     set_tracing_disabled(disabled=True)
 
-    class _LiteLLMModelProvider(ModelProvider):
+    if model_id.startswith(_TOKENROUTER_OPENAI_PREFIX):
+        return RunConfig(
+            model_provider=OpenAIProvider(
+                openai_client=client,
+                use_responses=True,
+            )
+        )
+
+    class _ChatCompletionsModelProvider(ModelProvider):
         def get_model(self, model_name: str | None):
             return OpenAIChatCompletionsModel(
                 model=model_name or resolved,
                 openai_client=client,
             )
 
-    return RunConfig(model_provider=_LiteLLMModelProvider())
+    return RunConfig(model_provider=_ChatCompletionsModelProvider())
 
 
 def _build_mcp_servers(

--- a/src/agent/openai_agent/tests/test_cli.py
+++ b/src/agent/openai_agent/tests/test_cli.py
@@ -1,0 +1,7 @@
+"""Tests for the OpenAI agent CLI."""
+
+from agent.openai_agent.cli import _build_parser
+
+
+def test_help_documents_tokenrouter_model_ids():
+    assert "tokenrouter/<model>" in _build_parser().format_help()

--- a/src/agent/openai_agent/tests/test_runner.py
+++ b/src/agent/openai_agent/tests/test_runner.py
@@ -65,27 +65,26 @@ def test_build_run_config_litellm_prefix(monkeypatch):
     assert model.model == "Azure/gpt-5-2025-08-07"
 
 
-def test_build_run_config_tokenrouter_openai_uses_responses(monkeypatch):
+@pytest.mark.parametrize(
+    ("model_id", "resolved_model"),
+    [
+        ("tokenrouter/openai/gpt-5.4", "openai/gpt-5.4"),
+        ("tokenrouter/anthropic/claude-opus-4.8", "anthropic/claude-opus-4.8"),
+        ("tokenrouter/MiniMax-M3", "MiniMax-M3"),
+    ],
+)
+def test_build_run_config_tokenrouter_uses_responses(
+    monkeypatch, model_id, resolved_model
+):
     monkeypatch.setenv("TOKENROUTER_BASE_URL", "https://api.tokenrouter.com/v1")
     monkeypatch.setenv("TOKENROUTER_API_KEY", "sk-test")
-    config = _build_run_config("tokenrouter/openai/gpt-5.4")
+    config = _build_run_config(model_id)
     assert config is not None
     assert isinstance(config.model_provider, OpenAIProvider)
-    model = config.model_provider.get_model("openai/gpt-5.4")
+    model = config.model_provider.get_model(resolved_model)
     assert isinstance(model, OpenAIResponsesModel)
-    assert model.model == "openai/gpt-5.4"
+    assert model.model == resolved_model
     assert str(model._client.base_url) == "https://api.tokenrouter.com/v1/"
-
-
-def test_build_run_config_tokenrouter_anthropic_uses_chat_completions(monkeypatch):
-    monkeypatch.setenv("TOKENROUTER_BASE_URL", "https://api.tokenrouter.com/v1")
-    monkeypatch.setenv("TOKENROUTER_API_KEY", "sk-test")
-    config = _build_run_config("tokenrouter/anthropic/claude-opus-4.8")
-    assert config is not None
-    assert config.model_provider is not None
-    model = config.model_provider.get_model(None)
-    assert isinstance(model, OpenAIChatCompletionsModel)
-    assert model.model == "anthropic/claude-opus-4.8"
 
 
 def test_build_run_config_missing_env_raises(monkeypatch):

--- a/src/agent/openai_agent/tests/test_runner.py
+++ b/src/agent/openai_agent/tests/test_runner.py
@@ -63,6 +63,7 @@ def test_build_run_config_litellm_prefix(monkeypatch):
     model = config.model_provider.get_model(None)
     assert isinstance(model, OpenAIChatCompletionsModel)
     assert model.model == "Azure/gpt-5-2025-08-07"
+    assert config.tracing_disabled is True
 
 
 @pytest.mark.parametrize(
@@ -85,6 +86,7 @@ def test_build_run_config_tokenrouter_uses_responses(
     assert isinstance(model, OpenAIResponsesModel)
     assert model.model == resolved_model
     assert str(model._client.base_url) == "https://api.tokenrouter.com/v1/"
+    assert config.tracing_disabled is True
 
 
 def test_build_run_config_missing_env_raises(monkeypatch):
@@ -138,19 +140,22 @@ def test_runner_litellm_model(monkeypatch):
 def _make_message_item(text: str):
     """Create a fake MessageOutputItem."""
     text_part = SimpleNamespace(text=text)
-    raw = SimpleNamespace(content=[text_part])
+    raw = SimpleNamespace(type="message", content=[text_part])
     return SimpleNamespace(type="message_output_item", raw_item=raw)
 
 
 def _make_tool_call_item(name: str, args: str, call_id: str = "call_1"):
     """Create a fake ToolCallItem."""
-    raw = SimpleNamespace(name=name, arguments=args, call_id=call_id)
+    raw = SimpleNamespace(
+        type="function_call", name=name, arguments=args, call_id=call_id
+    )
     return SimpleNamespace(type="tool_call_item", raw_item=raw)
 
 
-def _make_tool_output_item(output):
+def _make_tool_output_item(output, call_id: str = "call_1"):
     """Create a fake ToolCallOutputItem."""
-    return SimpleNamespace(type="tool_call_output_item", output=output)
+    raw = {"type": "function_call_output", "call_id": call_id, "output": output}
+    return SimpleNamespace(type="tool_call_output_item", raw_item=raw, output=output)
 
 
 def _make_usage(input_tokens: int, output_tokens: int):
@@ -225,7 +230,7 @@ def test_build_trajectory_multiple_tool_calls():
         _make_tool_call_item("sites", "{}", "call_1"),
         _make_tool_output_item(["MAIN"]),
         _make_tool_call_item("assets", '{"site_id": "MAIN"}', "call_2"),
-        _make_tool_output_item(["Chiller 6"]),
+        _make_tool_output_item(["Chiller 6"], "call_2"),
         _make_message_item("Found Chiller 6 at site MAIN."),
     ]
     # Two turns: (tool calls) and (message), so two raw_responses
@@ -244,6 +249,61 @@ def test_build_trajectory_multiple_tool_calls():
     assert traj.all_tool_calls[1].output == ["Chiller 6"]
     assert traj.total_input_tokens == 50 + 80
     assert traj.total_output_tokens == 10 + 15
+
+
+def test_build_trajectory_matches_batched_outputs_by_call_id():
+    first_call = _make_tool_call_item("sites", "{}", "call_1")
+    second_call = _make_tool_call_item(
+        "assets", '{"site_id": "MAIN"}', "call_2"
+    )
+    message = _make_message_item("Found Chiller 6 at site MAIN.")
+    items = [
+        first_call,
+        second_call,
+        _make_tool_output_item(["MAIN"], "call_1"),
+        _make_tool_output_item(["Chiller 6"], "call_2"),
+        message,
+    ]
+    raw_responses = [
+        SimpleNamespace(
+            output=[first_call.raw_item, second_call.raw_item],
+            usage=_make_usage(50, 10),
+        ),
+        SimpleNamespace(output=[message.raw_item], usage=_make_usage(80, 15)),
+    ]
+
+    traj = _build_trajectory(_make_run_result(items, raw_responses))
+
+    assert len(traj.turns) == 2
+    assert traj.all_tool_calls[0].output == ["MAIN"]
+    assert traj.all_tool_calls[1].output == ["Chiller 6"]
+
+
+def test_build_trajectory_preserves_sequential_response_usage():
+    first_call = _make_tool_call_item("sites", "{}", "call_1")
+    second_call = _make_tool_call_item(
+        "assets", '{"site_id": "MAIN"}', "call_2"
+    )
+    message = _make_message_item("Found Chiller 6 at site MAIN.")
+    items = [
+        first_call,
+        _make_tool_output_item(["MAIN"], "call_1"),
+        second_call,
+        _make_tool_output_item(["Chiller 6"], "call_2"),
+        message,
+    ]
+    raw_responses = [
+        SimpleNamespace(output=[first_call.raw_item], usage=_make_usage(10, 1)),
+        SimpleNamespace(output=[second_call.raw_item], usage=_make_usage(20, 2)),
+        SimpleNamespace(output=[message.raw_item], usage=_make_usage(30, 3)),
+    ]
+
+    traj = _build_trajectory(_make_run_result(items, raw_responses))
+
+    assert len(traj.turns) == 3
+    assert [turn.input_tokens for turn in traj.turns] == [10, 20, 30]
+    assert traj.total_input_tokens == 60
+    assert traj.total_output_tokens == 6
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent/openai_agent/tests/test_runner.py
+++ b/src/agent/openai_agent/tests/test_runner.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from agents import OpenAIChatCompletionsModel, OpenAIProvider, OpenAIResponsesModel
 
 from agent.openai_agent.runner import (
     OpenAIAgentRunner,
@@ -59,6 +60,32 @@ def test_build_run_config_litellm_prefix(monkeypatch):
     config = _build_run_config("litellm_proxy/Azure/gpt-5-2025-08-07")
     assert config is not None
     assert config.model_provider is not None
+    model = config.model_provider.get_model(None)
+    assert isinstance(model, OpenAIChatCompletionsModel)
+    assert model.model == "Azure/gpt-5-2025-08-07"
+
+
+def test_build_run_config_tokenrouter_openai_uses_responses(monkeypatch):
+    monkeypatch.setenv("TOKENROUTER_BASE_URL", "https://api.tokenrouter.com/v1")
+    monkeypatch.setenv("TOKENROUTER_API_KEY", "sk-test")
+    config = _build_run_config("tokenrouter/openai/gpt-5.4")
+    assert config is not None
+    assert isinstance(config.model_provider, OpenAIProvider)
+    model = config.model_provider.get_model("openai/gpt-5.4")
+    assert isinstance(model, OpenAIResponsesModel)
+    assert model.model == "openai/gpt-5.4"
+    assert str(model._client.base_url) == "https://api.tokenrouter.com/v1/"
+
+
+def test_build_run_config_tokenrouter_anthropic_uses_chat_completions(monkeypatch):
+    monkeypatch.setenv("TOKENROUTER_BASE_URL", "https://api.tokenrouter.com/v1")
+    monkeypatch.setenv("TOKENROUTER_API_KEY", "sk-test")
+    config = _build_run_config("tokenrouter/anthropic/claude-opus-4.8")
+    assert config is not None
+    assert config.model_provider is not None
+    model = config.model_provider.get_model(None)
+    assert isinstance(model, OpenAIChatCompletionsModel)
+    assert model.model == "anthropic/claude-opus-4.8"
 
 
 def test_build_run_config_missing_env_raises(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -314,7 +314,7 @@ requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.26.0" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "openai", specifier = ">=1.40.0" },
-    { name = "openai-agents", specifier = ">=0.0.7" },
+    { name = "openai-agents", specifier = ">=0.18.3" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "pendulum", specifier = ">=3.2.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -2890,7 +2890,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.31.0"
+version = "2.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2902,14 +2902,14 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/94/fe/64b3d035780b3188f86c4f6f1bc202e7bb74757ef028802112273b9dcacf/openai-2.31.0.tar.gz", hash = "sha256:43ca59a88fc973ad1848d86b98d7fac207e265ebbd1828b5e4bdfc85f79427a5", size = 684772, upload-time = "2026-04-08T21:01:41.797Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/d4d1835488c0350424009dac5095b9a3e173bee12fd2e421ee27e2142c42/openai-2.48.0.tar.gz", hash = "sha256:231b1e7661dda14574986c2f71451e9d584b7fe69e0ee6480e12ed090b48fc16", size = 1093427, upload-time = "2026-07-23T20:15:50.402Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/bc/a8f7c3aa03452fedbb9af8be83e959adba96a6b4a35e416faffcc959c568/openai-2.31.0-py3-none-any.whl", hash = "sha256:44e1344d87e56a493d649b17e2fac519d1368cbb0745f59f1957c4c26de50a0a", size = 1153479, upload-time = "2026-04-08T21:01:39.217Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/dcb891114e303c4379d4a498f10222e33eee540bcef4e1e493bd0af2b242/openai-2.48.0-py3-none-any.whl", hash = "sha256:c98df30aaaf93c51979f64d3e7c5b76464f8be0173368266229eb8fe6bd30f2c", size = 1648520, upload-time = "2026-07-23T20:15:48.052Z" },
 ]
 
 [[package]]
 name = "openai-agents"
-version = "0.13.6"
+version = "0.18.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "griffelib" },
@@ -2917,12 +2917,12 @@ dependencies = [
     { name = "openai" },
     { name = "pydantic" },
     { name = "requests" },
-    { name = "types-requests" },
     { name = "typing-extensions" },
+    { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/e8/a3bc1a91af9c71d2934f8e2f3eee2954540fa95d47b0e3f155d348d91b38/openai_agents-0.13.6.tar.gz", hash = "sha256:de7b3add7933ae704a5ee6e531f650d8aabb3ebaa1631f458ba39684a5ed966e", size = 2704270, upload-time = "2026-04-09T04:10:51.581Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/3f/b1162cad8720fafc9cf658d6896027385967f5006adfb92ae0dab2b54a70/openai_agents-0.18.3.tar.gz", hash = "sha256:e637f5f5a50692ccbedb0e4f7f2e4f8e2facfcddd41142f35faf90c89b700fc3", size = 5577652, upload-time = "2026-07-17T03:40:25.208Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/83/a991b2ad389abadabf13f6c4228bd88ac8dc363e4b50fcae8c5ea966bd41/openai_agents-0.13.6-py3-none-any.whl", hash = "sha256:8decb9eb0cc5dbe7749858e97a7d8316f9439526ca4e539e3bd105e0eb41115e", size = 471763, upload-time = "2026-04-09T04:10:49.81Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/7c/08b9929a15131081898e38c5612d44ee293851d5c80f31ca1153efe82143/openai_agents-0.18.3-py3-none-any.whl", hash = "sha256:c6ed971fdeb34d39a9931787bd3960c1e84dc5d7345705794cc5cab8a1158d07", size = 880799, upload-time = "2026-07-17T03:40:23.163Z" },
 ]
 
 [[package]]
@@ -5011,18 +5011,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/b6/3e681d3b6bb22647509bdbfdd18055d5adc0dce5c5585359fa46ff805fdc/typer-0.24.0.tar.gz", hash = "sha256:f9373dc4eff901350694f519f783c29b6d7a110fc0dcc11b1d7e353b85ca6504", size = 118380, upload-time = "2026-02-16T22:08:48.496Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/d0/4da85c2a45054bb661993c93524138ace4956cb075a7ae0c9d1deadc331b/typer-0.24.0-py3-none-any.whl", hash = "sha256:5fc435a9c8356f6160ed6e85a6301fdd6e3d8b2851da502050d1f92c5e9eddc8", size = 56441, upload-time = "2026-02-16T22:08:47.535Z" },
-]
-
-[[package]]
-name = "types-requests"
-version = "2.33.0.20260408"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- update `openai-agents` to 0.18.3 and refresh the uv lockfile
- route every `tokenrouter/...` model through the OpenAI Agents SDK Responses provider
- keep `litellm_proxy/...` models on Chat Completions
- reconstruct trajectories from SDK response boundaries so sequential turns retain complete usage
- match batched tool outputs to calls by `call_id`
- scope tracing disablement to routed runs instead of changing global SDK state
- document TokenRouter model IDs in CLI help

## Verification

- `uv run pytest src/agent/openai_agent/tests` (25 passed)
- `uv lock --check`
- live `MiniMax-M3` Responses run without MCP servers (successful; 1 turn, 229 input tokens, 2 output tokens)
- minimal `openai/gpt-5.4` request through TokenRouter `/v1/responses` (successful)
- minimal `MiniMax-M3` request through TokenRouter `/v1/responses` (successful)

## Known TokenRouter limitation

TokenRouter currently returns `500 convert_request_failed: not implemented` for `anthropic/claude-opus-4.8` on `/v1/responses`, even for a minimal request. This PR intentionally routes Anthropic models through Responses as well; those requests require corresponding TokenRouter support to succeed.