### PR TITLE
Persist Stirrup assistant reasoning in trajectories

### DIFF
--- a/src/agent/stirrup_agent/tests/test_runner.py
+++ b/src/agent/stirrup_agent/tests/test_runner.py
@@ -52,8 +52,15 @@ class _TC:
 
 
 @dataclass
+class _Reasoning:
+    content: str
+    signature: str | None = None
+
+
+@dataclass
 class _Assistant:
     content: str
+    reasoning: _Reasoning | None = None
     tool_calls: list = field(default_factory=list)
     token_usage: _Usage = field(default_factory=_Usage)
     request_start_time: float | None = None
@@ -192,6 +199,10 @@ def test_build_trajectory_maps_turns_calls_and_outputs():
         [
             _Assistant(
                 content="let me check work orders",
+                reasoning=_Reasoning(
+                    content="I should query the work-order tool.",
+                    signature="sig-1",
+                ),
                 tool_calls=[_TC("wo__get_work_order", '{"asset": "CWC04013"}', "t1")],
                 token_usage=_Usage(input=20, answer=8, reasoning=2),
                 request_start_time=1.0,
@@ -217,6 +228,11 @@ def test_build_trajectory_maps_turns_calls_and_outputs():
     assert len(traj.turns) == 2
     assert traj.total_input_tokens == 25
     assert traj.total_output_tokens == 16  # (8+2) + (6+0)
+    assert traj.turns[0].reasoning == {
+        "signature": "sig-1",
+        "content": "I should query the work-order tool.",
+    }
+    assert traj.turns[1].reasoning is None
 
     call = traj.all_tool_calls[0]
     assert call.name == "wo__get_work_order"

--- a/src/agent/stirrup_agent/trajectory.py
+++ b/src/agent/stirrup_agent/trajectory.py
@@ -8,7 +8,8 @@ attributes directly.
 
 Mapping:
   * each ``AssistantMessage`` -> one :class:`~agent.models.TurnRecord`
-    (its ``content`` text, ``tool_calls``, ``token_usage``, request timing);
+    (its ``content`` text, ``reasoning``, ``tool_calls``, ``token_usage``,
+    request timing);
   * each ``ToolMessage`` -> the ``output`` of the matching :class:`ToolCall`,
     joined by ``tool_call_id``.
 
@@ -20,6 +21,7 @@ runner) labels each call domain / code / other for the bypass metric.
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from typing import Any, Iterable
 
 from ..models import ToolCall, Trajectory, TurnRecord
@@ -29,6 +31,13 @@ from ..models import ToolCall, Trajectory, TurnRecord
 _CODE_TOOL_NAMES = {"code_exec"}
 # Default web tools, if ever attached; counted as "other", never domain.
 _WEB_TOOL_NAMES = {"web_search", "web_fetch"}
+
+
+@dataclass
+class StirrupTurnRecord(TurnRecord):
+    """A shared turn record plus Stirrup's optional reasoning payload."""
+
+    reasoning: dict[str, Any] | None = None
 
 
 def classify_tool(tool_name: str, domain_servers: set[str]) -> str:
@@ -79,6 +88,16 @@ def _parse_arguments(arguments: Any) -> dict:
     return {}
 
 
+def _reasoning_payload(reasoning: Any) -> dict[str, Any] | None:
+    """Return Stirrup ``AssistantMessage.reasoning`` in JSON-friendly form."""
+    if reasoning is None:
+        return None
+    return {
+        "signature": getattr(reasoning, "signature", None),
+        "content": getattr(reasoning, "content", "") or "",
+    }
+
+
 def _ms(start: float | None, end: float | None) -> float | None:
     if start is None or end is None:
         return None
@@ -123,7 +142,7 @@ def build_trajectory(history: Iterable[Any]) -> Trajectory:
             out_tok = getattr(usage, "output", 0) if usage else 0
 
             trajectory.turns.append(
-                TurnRecord(
+                StirrupTurnRecord(
                     index=turn_index,
                     text=_content_text(getattr(msg, "content", "")),
                     tool_calls=tool_calls,
@@ -133,6 +152,7 @@ def build_trajectory(history: Iterable[Any]) -> Trajectory:
                         getattr(msg, "request_start_time", None),
                         getattr(msg, "request_end_time", None),
                     ),
+                    reasoning=_reasoning_payload(getattr(msg, "reasoning", None)),
                 )
             )
             turn_index += 1


### PR DESCRIPTION
## Description
Persist the optional `AssistantMessage.reasoning` payload for Stirrup turns so tool-only turns can retain provider-supplied reasoning separately from visible assistant text.

## Fix Details
- Add a Stirrup-specific turn record with an optional `reasoning` field.
- Serialize reasoning as `{signature, content}` without changing `text` semantics.
- Leave the shared turn schema and other agent runners unchanged.
- Add coverage for populated and missing reasoning payloads.

## Impact on Benchmarking
- [ ] **No change to baselines**: This fix only improves stability/performance.
- [x] **Baseline change**: Persisted Stirrup trajectories now include reasoning when the provider supplies it. Agent answers, tool calls, token counts, and operational metrics are unchanged, but LLM-judge inputs may change because the evaluator serializes the complete trajectory. No full before-versus-after benchmark was run.

## Related Issues
- None.

## Verification Steps
1. Run `uv run pytest src/agent/stirrup_agent/tests/ -q`.
2. Confirm all 33 Stirrup tests pass.
3. Construct a Stirrup `AssistantMessage` with reasoning and confirm trajectory serialization contains `reasoning.signature` and `reasoning.content`.

## Checklist
- [x] I have added tests that prove my fix is effective.
- [x] My changes are Ruff-formatted. The repository has pre-existing lint findings under the latest standalone Ruff release in this test file.
- [x] I have signed off my commits (DCO).