### PR TITLE
fix(eval): persist plan-execute token usage for cost/tokens reporting

### DIFF
--- a/src/agent/plan_execute/runner.py
+++ b/src/agent/plan_execute/runner.py
@@ -181,5 +181,7 @@ class PlanExecuteRunner(AgentRunner):
                 question=question,
                 answer=answer or "",
                 trajectory=trajectory,
+                tokens_in=self._meter.input_tokens,
+                tokens_out=self._meter.output_tokens,
             )
             return result

--- a/src/agent/tests/test_runner.py
+++ b/src/agent/tests/test_runner.py
@@ -180,6 +180,38 @@ async def test_orchestrator_accumulates_token_usage_across_llm_calls():
 
 
 @pytest.mark.anyio
+async def test_orchestrator_persists_token_usage_alongside_trajectory(
+    monkeypatch, tmp_path
+):
+    """The meter's totals must reach the persisted record, not just the span.
+
+    Regression for the plan-execute runner's tracked usage never reaching
+    persist_trajectory(): metrics built from the persisted file (offline
+    evaluation) always saw tokens_in=tokens_out=0 for this runner.
+    """
+    from observability import set_run_context
+
+    monkeypatch.setenv("AGENT_TRAJECTORY_DIR", str(tmp_path))
+    set_run_context(run_id="run-usage")
+
+    llm = _UsageReportingLLM(
+        [
+            (_TWO_STEP_PLAN, 100, 50),
+            (_STEP1_ARGS, 20, 5),
+            (_STEP2_ARGS, 30, 5),
+            (_FINAL_ANSWER, 200, 40),
+        ]
+    )
+    runner = PlanExecuteRunner(llm)
+    with _patch_mcp()[0], _patch_mcp()[1]:
+        await runner.run("Q")
+
+    record = json.loads((tmp_path / "run-usage.json").read_text())
+    assert record["tokens_in"] == runner._meter.input_tokens == 350
+    assert record["tokens_out"] == runner._meter.output_tokens == 100
+
+
+@pytest.mark.anyio
 async def test_orchestrator_no_tool_returns_expected_output(sequential_llm):
     """A step with tool=none returns expected_output without any MCP or LLM call."""
     plan_with_no_tool = (

--- a/src/evaluation/metrics.py
+++ b/src/evaluation/metrics.py
@@ -31,7 +31,12 @@ def metrics_from_trajectory(record: PersistedTrajectory) -> OpsMetrics:
     if isinstance(traj, dict) and "turns" in traj:
         return _from_sdk_trajectory(traj, record.model)
     if isinstance(traj, list):
-        return _from_plan_execute(traj, record.model)
+        return _from_plan_execute(
+            traj,
+            record.model,
+            tokens_in=getattr(record, "tokens_in", None) or 0,
+            tokens_out=getattr(record, "tokens_out", None) or 0,
+        )
     return OpsMetrics()
 
 
@@ -128,10 +133,13 @@ def _usage_from_raw_events(events: list[Any]) -> tuple[int, int]:
     return input_tokens or sdk_input_tokens, output_tokens or sdk_output_tokens
 
 
-def _from_plan_execute(steps: list[Any], model: str) -> OpsMetrics:
+def _from_plan_execute(
+    steps: list[Any], model: str, tokens_in: int = 0, tokens_out: int = 0
+) -> OpsMetrics:
     # plan-execute persists ``list[StepResult]``; the dataclass exposes
     # ``server`` / ``tool`` / ``response`` fields but no per-step token
-    # counts, so we surface what is available and leave the rest at zero.
+    # counts, so the run-level totals the runner threaded onto the record
+    # (``tokens_in``/``tokens_out``) are the only source for these.
     tool_names = [
         s.get("tool")
         for s in steps
@@ -141,7 +149,9 @@ def _from_plan_execute(steps: list[Any], model: str) -> OpsMetrics:
         turn_count=len(steps),
         tool_call_count=len(tool_names),
         unique_tools=sorted(set(tool_names)),
-        est_cost_usd=_estimate_cost(model, 0, 0),
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        est_cost_usd=_estimate_cost(model, tokens_in, tokens_out),
     )
 
 

--- a/src/evaluation/tests/test_metrics.py
+++ b/src/evaluation/tests/test_metrics.py
@@ -103,6 +103,29 @@ class TestMetricsFromTrajectory:
         assert m.turn_count == 3
         assert m.tool_call_count == 3
         assert m.unique_tools == ["assets", "sites"]
+        # No run-level tokens_in/tokens_out on the record (pre-fix persisted
+        # files, or a runner that never set them): stay at zero, no cost.
+        assert m.tokens_in == 0
+        assert m.tokens_out == 0
+        assert m.est_cost_usd is None
+
+    def test_plan_execute_list_trajectory_reads_run_level_tokens(
+        self, make_persisted_record
+    ):
+        rec = PersistedTrajectory.from_raw(
+            make_persisted_record(
+                model="gpt-4o",
+                trajectory=[
+                    {"step_number": 1, "task": "t", "server": "iot", "tool": "sites", "response": "ok"},
+                ],
+                tokens_in=1000,
+                tokens_out=500,
+            )
+        )
+        m = metrics_from_trajectory(rec)
+        assert m.tokens_in == 1000
+        assert m.tokens_out == 500
+        assert m.est_cost_usd == round((1000 * 2.5 + 500 * 10.0) / 1_000_000, 6)
 
 
 class TestAggregateOps:

--- a/src/observability/persistence.py
+++ b/src/observability/persistence.py
@@ -43,12 +43,19 @@ def persist_trajectory(
     question: str,
     answer: str,
     trajectory: Any,
+    tokens_in: int | None = None,
+    tokens_out: int | None = None,
 ) -> Path | None:
     """Write a per-run evaluation record when ``AGENT_TRAJECTORY_DIR`` is set.
 
     Reads ``run_id`` / ``scenario_id`` from the same contextvars used by
     :func:`agent_run_span`, so CLI-level wiring doesn't have to touch the
     runner's public signature.
+
+    ``tokens_in`` / ``tokens_out`` are for runners (like plan-execute) whose
+    trajectory shape has no per-turn token fields of its own, so the totals
+    have to be threaded through separately. Omitted when ``None`` so callers
+    that don't pass them keep the record's existing shape.
 
     Returns the output path, or ``None`` when persistence is disabled.
     """
@@ -77,6 +84,10 @@ def persist_trajectory(
         "answer": answer,
         "trajectory": _serialize_trajectory(trajectory),
     }
+    if tokens_in is not None:
+        record["tokens_in"] = tokens_in
+    if tokens_out is not None:
+        record["tokens_out"] = tokens_out
     try:
         out_path.write_text(json.dumps(record, indent=2, default=str), encoding="utf-8")
     except OSError:

--- a/src/observability/tests/test_persistence.py
+++ b/src/observability/tests/test_persistence.py
@@ -116,6 +116,29 @@ def test_persist_serializes_list_trajectory(monkeypatch, tmp_path: Path):
     assert record["trajectory"] == [
         {"step_number": 1, "task": "do thing", "success": True}
     ]
+    assert "tokens_in" not in record
+    assert "tokens_out" not in record
+
+
+def test_persist_includes_run_level_tokens_when_given(monkeypatch, tmp_path: Path):
+    """plan-execute's trajectory has no per-turn token fields, so the runner
+    passes the meter's totals separately; they must land on the record."""
+    monkeypatch.setenv("AGENT_TRAJECTORY_DIR", str(tmp_path))
+    set_run_context(run_id="r4")
+
+    out = persist_trajectory(
+        runner_name="plan-execute",
+        model="watsonx/model",
+        question="q",
+        answer="a",
+        trajectory=[],
+        tokens_in=42,
+        tokens_out=17,
+    )
+
+    record = json.loads(out.read_text())
+    assert record["tokens_in"] == 42
+    assert record["tokens_out"] == 17
 
 
 def test_persist_skips_when_no_run_id(monkeypatch, tmp_path: Path, caplog):


### PR DESCRIPTION
## Description

`PlanExecuteRunner` meters real token usage via `_TokenMeter` and writes accurate totals onto the OTel span (`gen_ai.usage.input_tokens`/`output_tokens`), but that data never reaches the persisted trajectory. `persist_trajectory()` only receives `trajectory=list[StepResult]`, and `StepResult` has no token field, so `_from_plan_execute()` in `src/evaluation/metrics.py` always builds `OpsMetrics` with `tokens_in=tokens_out=0`, and `_estimate_cost(model, 0, 0)` short-circuits to `None`. Every offline evaluation report shows zero tokens and no cost for the plan-execute agent specifically; every SDK-based runner reports correctly because their `Trajectory` dataclass carries per-turn token fields.

## Fix Details

Thread the meter's totals through as two new optional keyword arguments on `persist_trajectory()` (`tokens_in`, `tokens_out`), written onto the record only when given, so the six other runners' calls and their persisted shape are unchanged. `PlanExecuteRunner.run()` now passes `self._meter.input_tokens`/`output_tokens`. `metrics_from_trajectory()` reads them back off the record (`getattr(..., None) or 0`, so older persisted files without these keys still parse) and passes them into `_from_plan_execute()`, which now populates `OpsMetrics.tokens_in`/`tokens_out` and the cost estimate instead of hardcoding zeros.

## Impact on Benchmarking

- [x] **Baseline change**: `tokens_in`, `tokens_out` and `est_cost_usd` for plan-execute scenario results move from always `0`/`None` to the run's real usage. `aggregate_ops()`'s existing sums (`tokens_in_total`, `tokens_out_total`, `est_cost_usd_total`) are the only readers of these fields elsewhere in the codebase, and they already treat a `None` cost as excluded, so no other code path assumed the old zeros.

## Related Issues
- Fixes: #499

## Verification Steps

- New regression tests (`test_orchestrator_persists_token_usage_alongside_trajectory`, `test_persist_includes_run_level_tokens_when_given`, `test_plan_execute_list_trajectory_reads_run_level_tokens`) fail against unmodified `main` and pass on this branch; ran in a clean `python:3.12-slim` container with `uv sync`, `__file__`-checked against `/repo/src/...`.
- Full suite for the three touched modules (`src/agent/tests/`, `src/evaluation/tests/`, `src/observability/tests/`): 187 passed, 8 pre-existing failures unrelated to this change (missing `google.protobuf` in `test_file_exporter.py`, an unrelated scorer issue in `test_static_json_scorer.py`), same 8 failing identically on unmodified `main`.
- `coverage run`/`report` confirms every changed line in the three touched files is covered.
- Not checked: no live `AGENT_TRAJECTORY_DIR`/evaluation-CLI run against a real LLM backend; the repro is the unit/integration test suite above, not a manual end-to-end run.

## Checklist
- [x] I have added tests that prove my fix is effective.
- [ ] My code follows the project's Ruff formatting and linting rules. (repo has no Ruff config or dependency; nothing to run)
- [x] I have signed off my commits (DCO).
