### PR TITLE
fix(scorers): a digit inside a name is not a count

### DIFF
--- a/src/evaluation/scorers/static_json.py
+++ b/src/evaluation/scorers/static_json.py
@@ -209,6 +209,16 @@ def _parse_json_or_python(content: str) -> Any:
     return _PARSE_MISSING
 
 
+# Wording that may surround a bare count without making the answer something
+# other than a count. Anything else left over means the number was part of a
+# phrase -- most importantly, part of a name.
+_COUNT_WORDS = re.compile(
+    r"\b(?:the|a|an|final|answer|count|result|total|is|are|there|of|"
+    r"assets?|items?|records?|rows?|entries)\b",
+    flags=re.IGNORECASE,
+)
+
+
 def _extract_count_from_text(content: str) -> int | float | None:
     """Extract a count when the answer is count-only or nearly count-only."""
     stripped = content.strip()
@@ -225,7 +235,24 @@ def _extract_count_from_text(content: str) -> int | float | None:
     )
     if len(numbers) == 1:
         number = numbers[0]
-        return float(number) if "." in number else int(number)
+        # A digit inside a name is not a count.
+        #
+        # This function is documented as accepting answers that are "count-only
+        # or nearly count-only", but a single number anywhere in the text
+        # satisfied that test. So "Chiller 6" parsed as 6 -- and so did
+        # "Boiler 6", making two differently-named assets compare equal on a
+        # digit that happened to be inside a name.
+        #
+        # Require the residue, once the number and the usual count wording are
+        # removed, to contain no remaining words: that is what "nearly
+        # count-only" means. "The count is 6" still parses; "Chiller 6" no
+        # longer does.
+        residue = re.sub(
+            r"(?<![A-Za-z0-9_])-?\d+(?:\.\d+)?(?![A-Za-z0-9_])", " ", stripped
+        )
+        residue = _COUNT_WORDS.sub(" ", residue)
+        if not re.search(r"[A-Za-z0-9]", residue):
+            return float(number) if "." in number else int(number)
 
     return None
 

--- a/src/evaluation/tests/test_static_json_scorer.py
+++ b/src/evaluation/tests/test_static_json_scorer.py
@@ -557,3 +557,25 @@ def test_static_json_scorer_uses_car_metadata_score():
     assert result.passed is True
     assert result.score == 1.0
     assert result.details["car_score"] == 1.0
+
+
+def test_digit_inside_an_asset_name_is_not_a_count():
+    """A number inside a name is not a count.
+
+    `_extract_count_from_text` accepted any text containing exactly one number,
+    so "Chiller 6" parsed as 6. Two differently-named assets then compared equal
+    on the digit, and a wrong asset scored as a perfect match while a different
+    wrong asset scored zero.
+    """
+    assert parse_structured_answer("Chiller 6") == "Chiller 6"
+    assert parse_structured_answer("Boiler 6") == "Boiler 6"
+    assert parse_structured_answer("Chiller 6") != parse_structured_answer("Boiler 6")
+
+
+def test_count_only_answers_still_parse_as_counts():
+    """The intended behaviour is preserved: count-only or nearly count-only."""
+    assert parse_structured_answer("6") == 6
+    assert parse_structured_answer("  6  ") == 6
+    assert parse_structured_answer("The count is 6") == 6
+    assert parse_structured_answer("Answer: 6.") == 6
+    assert parse_structured_answer("3.5") == 3.5


### PR DESCRIPTION
## Description

`_extract_count_from_text` accepted any answer containing exactly one number,
wherever that number sat. `"Chiller 6"` therefore parsed as `6` — and so did
`"Boiler 6"`, so two differently-named assets compared equal on a digit that
happened to be inside a name.

A wrong asset scored a perfect strict match while a *different* wrong asset
scored zero. Full report in #504.

## Fix Details

The docstring already states the intent — *"count-only or nearly count-only"* —
and this enforces it rather than changing it. After the number and the usual
count wording are removed, **any remaining word means the number was part of a
phrase**, most importantly part of a name.

The change lands in `_extract_count_from_text`, which covers both entry points:
the direct call in `parse_structured_answer`, and the delegation from
`_extract_final_count_from_text` (which `parse_structured_answer` reaches first).

| input | `parse_structured_answer` before | after |
|---|---|---|
| `"Chiller 6"` | `6` | `'Chiller 6'` |
| `"Boiler 6"` | `6` | `'Boiler 6'` |
| `"The count is 6"` | `6` | `6` |
| `"There are 5 assets"` | `5` | `5` |
| `"Answer: 6"` | `6` | `6` |
| `"6"` | `6` | `6` |

## Impact on Benchmarking

- [x] **Baseline change**: This fix corrects a scoring error.

**Before vs. After.** The correction only ever removes false *positives*, so
scores can fall but not rise. Observed on scenario 3 via this repository's own
`plan_execute` runner: the answer *"The MAIN site has five assets: Chiller 6,
Motor_01, PUMP3, hyd_1, and mp_1"* reduced to `{'answer': '6'}` before, and is
now compared as the string it is.

Any published number computed against a **list-shaped gold whose entries contain
digits** may have been inflated. Golds that are genuine counts are unaffected —
every count form in the table above still parses.

## Related Issues

- Fixes: #504
- Adjacent, opposite direction: #494 and #475 report this same extraction path
  losing *correct* answers. This one accepts *wrong* ones. A fix for either that
  treats the extractor as "harvest a number from the text" will leave the other
  in place. **Happy to fold this into whatever #494's assignee is already
  doing**, or to close it in favour of a combined change — please just say which
  you prefer.

## Verification Steps

1. `tests/integration` does not exist at `e11d1c1`, so the template's command
   has nothing to run. What was run instead, from `src/`:

   ```
   python -m pytest evaluation/tests/ -q
   ```

   `main` at `e11d1c1`: **6 failed / 90 passed**
   this branch:         **6 failed / 92 passed**

   The 6 failures are pre-existing and untouched by this change —
   `test_car_metadata_*` and `test_static_json_scorer_uses_car_metadata_score`,
   all failing on `KeyError: 'car_score'`. Flagging so a red run here is not
   read as this PR's doing; happy to file them separately if useful.

2. Manual verification, from `src/`:

   ```python
   from evaluation.scorers.static_json import parse_structured_answer as p
   p("Chiller 6")        # main -> 6      this branch -> 'Chiller 6'
   p("The count is 6")   # main -> 6      this branch -> 6
   ```

   Both extractor frames were instrumented to confirm the fix sits on the path
   `parse_structured_answer` actually takes.

## Checklist

- [x] I have added tests that prove my fix is effective. (+2 tests)
- [x] My code follows the project's Ruff formatting and linting rules.
      Precisely: this change introduces **no new** findings. `ruff check` reports
      the same 3 findings on `main` and on this branch (`SIM118`, `ISC004`,
      `I001`), and `ruff format` does not touch a single added line — the format
      drift in both files is pre-existing at `e11d1c1`. I have deliberately not
      reformatted the files, to keep the diff to the fix.
- [x] I have signed off my commits (DCO).
