### PR TITLE
docs(evaluation): what the public data supports — the scoreability section for #506, #507, #508, #509

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -74,6 +74,20 @@ correct answer follows from the database the default manifest loads:
   the guideline gives an answer for a site or asset, verify it against the
   loaded collections before treating it as gold.
 
+**Two questions are answerable without the tools.** Running each derivable
+question with **no MCP servers mounted at all**, twelve returned nothing usable
+— which is what a tool-use question should do — and two did not:
+
+| id | question | why |
+|---|---|---|
+| 205 | *"Is LSTM model supported in TSFM?"* | answerable from general model knowledge |
+| 206 | *"Is Chronos model supported in TSFM?"* | answerable from general model knowledge |
+
+They are useful as controls, but a system that answers them has not
+demonstrated tool use, and counting them toward a tool-use score credits the
+model's priors rather than its retrieval. Scope them out of that measurement, or
+report them separately.
+
 None of this is a defect in the questions. It is the difference between the
 public artefacts and the internal dataset the guideline was written against, and
 knowing it in advance saves reconstructing it from failing runs.

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -34,6 +34,50 @@ The vocabulary follows MLflow's evaluation split:
 - **Evaluator** — orchestrates a batch: loads scenarios + trajectories,
   joins on `scenario_id`, dispatches to scorers, aggregates results.
 
+## What the public data supports
+
+**The public artefacts are not scoreable end-to-end for most scenario
+questions.** The ground truth referenced by the design guideline is the
+*AssetOpsBench Ground Truth Dataset (IBM Internal)*; the public HuggingFace
+dataset ships questions only. This section states what can and cannot be graded
+against the data this repository loads, so that gap is discovered here rather
+than after a run.
+
+Taking every scenario question in the utterance set and asking whether the
+correct answer follows from the database the default manifest loads:
+
+| disposition | n | meaning |
+|---|---|---|
+| **derivable** | **14** | the answer follows from the loaded data |
+| identifier mismatch | 12 | identifiers in the question match none in the data |
+| entity absent | 10 | the question names equipment the data does not contain |
+| input file absent | 8 | a file the question depends on is not in the repository |
+| ambiguous source | 6 | two shipped sources answer the same question differently |
+| answer shape | 3 | the expected answer cannot be expressed unambiguously |
+| window absent | 2 | the time window asked about is not in the series |
+| | **55** | |
+
+**Practical consequences when evaluating against the public data:**
+
+- **An aggregate over all scenario questions is dominated by questions that
+  cannot be graded**, not by model performance. Scope any reported score to the
+  subset you verified as derivable.
+- **Ambiguous-source questions are the ones to watch**, because they fail
+  silently. Absent data produces an obvious error; two shipped sources
+  disagreeing produces a confident wrong grade.
+- **The MCQA pools carry answer keys and are therefore attractive for automated
+  evaluation, but none of their questions reference a loaded database entity.**
+  They test general engineering knowledge. A system evaluated on that pool is
+  not being evaluated on its tool use, and an experiment varying tool access
+  will find no effect there.
+- **Documented example answers may not match the shipped sample data.** Where
+  the guideline gives an answer for a site or asset, verify it against the
+  loaded collections before treating it as gold.
+
+None of this is a defect in the questions. It is the difference between the
+public artefacts and the internal dataset the guideline was written against, and
+knowing it in advance saves reconstructing it from failing runs.
+
 ## Inputs
 
 ### Scenario file

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -36,12 +36,12 @@ The vocabulary follows MLflow's evaluation split:
 
 ## What the public data supports
 
-**The public artefacts are not scoreable end-to-end for most scenario
-questions.** The ground truth referenced by the design guideline is the
-*AssetOpsBench Ground Truth Dataset (IBM Internal)*; the public HuggingFace
-dataset ships questions only. This section states what can and cannot be graded
-against the data this repository loads, so that gap is discovered here rather
-than after a run.
+**As shipped, most scenario questions cannot be graded against the data this
+repository loads.** Whether that is intended is a separate question: the design
+guideline references an *AssetOpsBench Ground Truth Dataset (IBM Internal)*, and
+the public HuggingFace dataset ships questions only. This section records what
+can and cannot be graded against the loaded data, so the gap is found here
+rather than after a run.
 
 Taking every scenario question in the utterance set and asking whether the
 correct answer follows from the database the default manifest loads:
@@ -67,9 +67,12 @@ correct answer follows from the database the default manifest loads:
   disagreeing produces a confident wrong grade.
 - **The MCQA pools carry answer keys and are therefore attractive for automated
   evaluation, but none of their questions reference a loaded database entity.**
-  They test general engineering knowledge. A system evaluated on that pool is
-  not being evaluated on its tool use, and an experiment varying tool access
-  will find no effect there.
+  Counted at dataset revision `5e25bb7f`: **0 of 2,667** FailureSensorIQ
+  questions name any asset, site or model present in the loaded collections —
+  under an exact match and under one that ignores separators, so `Chiller 6`
+  and `CHILLER6` count as the same name. They test general engineering
+  knowledge. A system evaluated on that pool is not being evaluated on its tool
+  use, and an experiment varying tool access will find no effect there.
 - **Documented example answers may not match the shipped sample data.** Where
   the guideline gives an answer for a site or asset, verify it against the
   loaded collections before treating it as gold.


### PR DESCRIPTION
## Description

Four issues — #506, #507, #508 and #509 — describe the same thing from different
angles: what the public artefacts do and do not support when used for scoring.
**They share a fix location rather than a root cause**, so this is one section
rather than four scattered edits, as promised in #506.

It adds a *"What the public data supports"* section to `docs/evaluation.md`,
which already describes scoring and is where someone choosing a scorer is
already reading.

## Changes

- [x] **Documentation / Tutorial update**

One file, `docs/evaluation.md`, +61 lines. No code touched.

| what it records | issue |
|---|---|
| that most scenario questions cannot be graded against the loaded data as shipped, and that the guideline's ground truth is an internal dataset | #506 |
| the disposition of all 55 scenario questions — 14 derivable, 41 not, by category | #507 |
| that the MCQA pools carry answer keys but reference no loaded entity — 0 of 2,667 | #509 |
| that scenarios 205 and 206 are answerable with no tools mounted | #508 |

## Verification Steps

1. `tests/integration` does not exist at `e11d1c1`; nothing here is executable
   in any case — the change is documentation only, no code path is touched.
2. The numbers are derived rather than asserted:
   - **dispositions** — an exhaustive pass over all 55 scenario questions, with
     the executable selector recorded per derivation.
   - **0 of 2,667** — counted at dataset revision
     `5e25bb7f2cd37fb68b9a9e1f99d170ca5be7ce17`, under an exact match and under
     one that ignores separators so `Chiller 6` and `CHILLER6` count as the same
     name. Reported for every candidate denominator, not just the headline one.
   - **205 / 206** — a screen run with no MCP servers mounted *before* any
     measurement, excluding on a single correct answer in three.

## Checklist

- [x] I have signed off my commits (DCO).

## Note

**The wording is a proposal, not a position.** #506 asks whether the public
artefacts are meant to be scoreable end-to-end without the internal dataset, and
that question is still open — this section deliberately states what we
*measured* and names the question of intent as separate, rather than answering
it on your behalf.

**If the answer to #506 is "the public data is a sample, not a gradeable set",
this section should say so in your words rather than ours.** Happy to rewrite
it, move it elsewhere, split it into four, or close this if you would rather
write it yourselves.
