### PR TITLE
fix(llm): fail on an empty completion where it happens, and make the cap overridable

### DIFF
--- a/src/llm/base.py
+++ b/src/llm/base.py
@@ -6,6 +6,41 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 
 
+class EmptyCompletionError(RuntimeError):
+    """The backend returned a completion with no visible content.
+
+    Raised where it happens rather than letting ``None`` travel. A reasoning
+    model can spend its whole token budget on ``reasoning_content`` and return
+    ``content=None`` with ``finish_reason='length'``; passed on, that surfaces
+    several frames later as ``TypeError: expected string or bytes-like object,
+    got 'NoneType'`` inside a regex, which blames the parser for the backend's
+    result.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        finish_reason: str | None = None,
+        completion_tokens: int = 0,
+        max_tokens: int | None = None,
+    ) -> None:
+        self.model = model
+        self.finish_reason = finish_reason
+        self.completion_tokens = completion_tokens
+        self.max_tokens = max_tokens
+
+        detail = f"{model} returned no content (finish_reason={finish_reason!r})"
+        if finish_reason == "length":
+            detail += (
+                f"; the completion hit the token cap"
+                f"{f' of {max_tokens}' if max_tokens else ''}"
+                f" after {completion_tokens} tokens, which reasoning models can"
+                f" consume entirely on reasoning_content. Raise the cap with"
+                f" AOB_LLM_MAX_TOKENS."
+            )
+        super().__init__(detail)
+
+
 @dataclass(frozen=True)
 class LLMResult:
     """Return type for :meth:`LLMBackend.generate_with_usage`.

--- a/src/llm/litellm.py
+++ b/src/llm/litellm.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import os
 
-from .base import LLMBackend, LLMResult
+from .base import EmptyCompletionError, LLMBackend, LLMResult
 
 _WATSONX_PREFIX = "watsonx/"
 
@@ -43,7 +43,10 @@ class LiteLLMBackend(LLMBackend):
             "model": self._model_id,
             "messages": [{"role": "user", "content": prompt}],
             "temperature": temperature,
-            "max_tokens": 2048,
+            # Overridable: 2048 is comfortable for a non-reasoning model and
+            # too tight for one that emits reasoning_content, where the visible
+            # answer is what is left after the thinking is paid for.
+            "max_tokens": int(os.environ.get("AOB_LLM_MAX_TOKENS", "2048")),
         }
 
         if self._model_id.startswith(_WATSONX_PREFIX):
@@ -57,8 +60,25 @@ class LiteLLMBackend(LLMBackend):
 
         response = litellm.completion(**kwargs)
         usage = getattr(response, "usage", None)
+        choice = response.choices[0]
+        text = choice.message.content
+        completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0)
+
+        # Fail where the fact is, not four frames later. `content` is None
+        # whenever the model produced no visible text -- most often a reasoning
+        # model that spent the whole cap on reasoning_content and stopped with
+        # finish_reason='length'. Returning it lets a TypeError surface inside
+        # parse_plan's regex, blaming the parser for the backend's result.
+        if text is None:
+            raise EmptyCompletionError(
+                model=self._model_id,
+                finish_reason=getattr(choice, "finish_reason", None),
+                completion_tokens=completion_tokens,
+                max_tokens=kwargs.get("max_tokens"),
+            )
+
         return LLMResult(
-            text=response.choices[0].message.content,
+            text=text,
             input_tokens=int(getattr(usage, "prompt_tokens", 0) or 0),
-            output_tokens=int(getattr(usage, "completion_tokens", 0) or 0),
+            output_tokens=completion_tokens,
         )

--- a/src/llm/tests/test_empty_completion.py
+++ b/src/llm/tests/test_empty_completion.py
@@ -1,0 +1,101 @@
+"""An empty completion must fail where it happens, not four frames later.
+
+`content` is None whenever the model produced no visible text -- most often a
+reasoning model that spent its whole token budget on `reasoning_content` and
+stopped with finish_reason='length'. Returning that None let it travel into
+`plan_execute.planner.parse_plan`, where a regex raised
+
+    TypeError: expected string or bytes-like object, got 'NoneType'
+
+blaming the parser for the backend's result.
+"""
+
+import sys
+import types
+
+import pytest
+
+from llm.base import EmptyCompletionError
+from llm.litellm import LiteLLMBackend
+
+
+def _response(content, finish_reason="stop", completion_tokens=2048):
+    """A litellm-shaped response object."""
+    message = types.SimpleNamespace(content=content)
+    choice = types.SimpleNamespace(message=message, finish_reason=finish_reason)
+    usage = types.SimpleNamespace(
+        prompt_tokens=100, completion_tokens=completion_tokens
+    )
+    return types.SimpleNamespace(choices=[choice], usage=usage)
+
+
+@pytest.fixture
+def fake_litellm(monkeypatch):
+    """Stand in for the litellm module the backend imports at call time."""
+    module = types.ModuleType("litellm")
+    module.captured = {}
+
+    def completion(**kwargs):
+        module.captured.update(kwargs)
+        return module.next_response
+
+    module.completion = completion
+    monkeypatch.setitem(sys.modules, "litellm", module)
+    monkeypatch.setenv("LITELLM_API_KEY", "test-key")
+    monkeypatch.setenv("LITELLM_BASE_URL", "http://localhost")
+    return module
+
+
+def test_empty_content_raises_where_it_happens(fake_litellm):
+    fake_litellm.next_response = _response(None, finish_reason="length")
+    backend = LiteLLMBackend("litellm_proxy/some-reasoning-model")
+
+    with pytest.raises(EmptyCompletionError) as excinfo:
+        backend.generate_with_usage("plan this")
+
+    error = excinfo.value
+    assert error.finish_reason == "length"
+    assert error.completion_tokens == 2048
+    # The message must name the cause, not merely the symptom.
+    assert "token cap" in str(error)
+    assert "AOB_LLM_MAX_TOKENS" in str(error)
+
+
+def test_empty_content_for_other_reasons_still_raises(fake_litellm):
+    fake_litellm.next_response = _response(None, finish_reason="content_filter")
+    backend = LiteLLMBackend("litellm_proxy/model")
+
+    with pytest.raises(EmptyCompletionError) as excinfo:
+        backend.generate_with_usage("prompt")
+    assert excinfo.value.finish_reason == "content_filter"
+
+
+def test_ordinary_completions_are_unaffected(fake_litellm):
+    fake_litellm.next_response = _response("1. do the thing")
+    backend = LiteLLMBackend("litellm_proxy/model")
+
+    result = backend.generate_with_usage("prompt")
+    assert result.text == "1. do the thing"
+    assert result.input_tokens == 100
+    assert result.output_tokens == 2048
+
+
+def test_empty_string_is_not_an_empty_completion(fake_litellm):
+    """Only None means "no content". An empty string is a real answer shape."""
+    fake_litellm.next_response = _response("")
+    backend = LiteLLMBackend("litellm_proxy/model")
+    assert backend.generate_with_usage("prompt").text == ""
+
+
+def test_token_cap_is_overridable(fake_litellm, monkeypatch):
+    monkeypatch.setenv("AOB_LLM_MAX_TOKENS", "8192")
+    fake_litellm.next_response = _response("ok")
+    LiteLLMBackend("litellm_proxy/model").generate_with_usage("prompt")
+    assert fake_litellm.captured["max_tokens"] == 8192
+
+
+def test_token_cap_defaults_to_the_previous_value(fake_litellm, monkeypatch):
+    monkeypatch.delenv("AOB_LLM_MAX_TOKENS", raising=False)
+    fake_litellm.next_response = _response("ok")
+    LiteLLMBackend("litellm_proxy/model").generate_with_usage("prompt")
+    assert fake_litellm.captured["max_tokens"] == 2048


### PR DESCRIPTION
## Description

A completion with no visible content currently travels as `None` from
`LiteLLMBackend` into `parse_plan`, where it reaches a regex and raises:

```
TypeError: expected string or bytes-like object, got 'NoneType'
```

**The traceback names `_TASK_RE.finditer` — four frames from the cause** — and
mentions neither `max_tokens` nor `finish_reason`. Full report in #511.

## Fix Details

**Two changes, both small.**

**1. Raise where the fact is.** `EmptyCompletionError` is raised in
`LiteLLMBackend.generate_with_usage`, **after the completion returns and before
`LLMResult` is constructed** — so a `None` never enters the system. The message
carries the model, `finish_reason`, tokens consumed and the cap:

```
<model> returned no content (finish_reason='length'); the completion hit the
token cap of 2048 after 2048 tokens, which reasoning models can consume
entirely on reasoning_content. Raise the cap with AOB_LLM_MAX_TOKENS.
```

**2. Make the cap overridable.** `max_tokens` reads `AOB_LLM_MAX_TOKENS`,
**defaulting to the current 2048** — so behaviour is unchanged unless someone
changes it.

**What this deliberately does not do:** no retry, no fallback, no silent empty
string. Those are policy decisions for the project; this makes the failure
legible so the policy can be chosen with the facts visible.

## Impact on Benchmarking

- [x] **No change to baselines**: this only converts a crash into a named error.

A run that previously died with a `TypeError` now dies with an
`EmptyCompletionError` naming the cause. **No run that previously succeeded
behaves differently** — the raise fires only where `content` is `None`, which is
already fatal today.

## Related Issues

- Fixes the defect reported in #511.

## Verification Steps

1. `tests/integration` does not exist at `e11d1c1`. What was run instead, from
   `src/`:

   ```
   python -m pytest llm/tests/ -q
   ```

   `main` at `e11d1c1`: **19 passed**
   this branch:         **25 passed** (+6)

   The six new tests, one per behaviour:

   | test | what it pins |
   |---|---|
   | `empty_content_raises_where_it_happens` | `content=None`, `finish_reason='length'` → raises, cap named |
   | `empty_content_for_other_reasons_still_raises` | not only the `length` case |
   | `ordinary_completions_are_unaffected` | the success path is untouched |
   | `empty_string_is_not_an_empty_completion` | **`""` is a valid answer and must pass through** — only `None` raises |
   | `token_cap_is_overridable` | `AOB_LLM_MAX_TOKENS` takes effect |
   | `token_cap_defaults_to_the_previous_value` | absent the env var, still 2048 |

2. The 6 pre-existing failures in `src/evaluation/tests/` are untouched — this
   branch does not import from `evaluation`.

3. **`AOB_LLM_MAX_TOKENS` is read in-process and never crosses a spawn.**
   `os.environ.get` at `litellm.py:49` and `litellm.completion` at `:61` are in
   the same function in the same process, `litellm` is imported in-process, and
   there is no `subprocess` or `Popen` anywhere under `src/llm/`. Checked
   deliberately: a fix introducing a new environment variable should not depend
   on that variable surviving a process boundary.

## Checklist

- [x] I have added tests that prove my fix is effective. (+6)
- [x] My code follows the project's Ruff formatting and linting rules.
      `ruff check src/llm/` — **all checks passed**; `ruff format --check
      src/llm/` — **9 files already formatted**, on this branch. Unlike the
      scorer files, this path is clean both before and after.
- [x] I have signed off my commits (DCO).
