### PR TITLE
feat(benchmarks): add model matrix run script

### DIFF
--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scenario_dir="${1:-${SCENARIO_DIR:-}}"
+leaderboard_dir="${2:-${LEADERBOARD_DIR:-}}"
+
+if [[ -z "$scenario_dir" || -z "$leaderboard_dir" ]]; then
+  printf 'Usage: %s SCENARIO_DIR LEADERBOARD_DIR\n' "$0" >&2
+  printf '       or set SCENARIO_DIR and LEADERBOARD_DIR\n' >&2
+  exit 2
+fi
+
+agent_name=stirrup_agent
+scenario_ids=lite
+
+model_configs=(
+  "litellm_proxy/gcp/gemini-3.6-flash high"
+  "litellm_proxy/azure/gpt-5.6-sol max"
+  "tokenrouter/z-ai/glm-5.2 max"
+  "tokenrouter/MiniMax-M3 high"
+  "litellm_proxy/aws/claude-opus-5 high"
+  "litellm_proxy/azure/DeepSeek-V4-Flash max"
+  "litellm_proxy/aws/gpt-oss-120b high"
+  "litellm_proxy/aws/claude-sonnet-5 max"
+)
+
+for model_config in "${model_configs[@]}"; do
+  read -r model_id reasoning_effort <<< "$model_config"
+
+  echo "Running $model_id with reasoning effort $reasoning_effort"
+
+  uv run python -m benchmark.scenario_suite_runner \
+    --scenario-ids "$scenario_ids" \
+    --scenario-root "$scenario_dir" \
+    --agent_name "$agent_name" \
+    --model-id "$model_id" \
+    --reasoning-effort "$reasoning_effort" \
+    --trajectory-root "$leaderboard_dir/assetopsbench-trajectories" \
+    --reports-root "$leaderboard_dir/assetopsbench-reports" \
+    --stirrup-workspace-root "$leaderboard_dir/assetopsbench-stirrup-workspaces" \
+    --skip-existing \
+    --continue-on-error
+done


### PR DESCRIPTION
## Description
Adds an executable `benchmarks/run.sh` launcher for running the lite scenario suite across the configured eight-model Stirrup benchmark matrix. The script accepts scenario and leaderboard roots via positional arguments or environment variables, validates required inputs, skips existing trajectories, and continues across individual scenario errors.

## Type of Change
- [ ] New Benchmark Scenario (Industry/Asset type)
- [ ] Evaluation Metric / Scorer
- [ ] Agentic Orchestration Logic (ReAct, Plan-Execute, etc.)
- [x] Infrastructure / Tooling Improvement

## Industry Relevance
Provides a repeatable model-comparison entry point and consistent output layout for benchmark trajectories, reports, and Stirrup workspaces.

## Related Issues
- None

## Testing & Validation
- [x] **Unit Tests**: `43 passed` in `src/benchmark/tests/test_scenario_suite_runner.py`.
- [x] **Scenario Validation**: Mocked `uv` and verified all eight correctly quoted runner invocations.
- [x] **Shell Validation**: `bash -n benchmarks/run.sh` and missing-argument behavior passed.
- [x] **Data Integrity**: No benchmark data, PII, credentials, or sensitive industrial data added.

## Checklist
- [x] The script follows repository shell conventions and passes syntax validation.
- [x] I have performed a self-review.
- [x] The script includes inline usage guidance for required inputs.
- [x] I have signed off the commit (DCO).